### PR TITLE
Add test run tracking models and migrations

### DIFF
--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -879,6 +879,31 @@ class Asset extends Depreciable
     }
 
     /**
+     * Get the test runs for this asset
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\Relation
+     */
+    public function testRuns()
+    {
+        return $this->hasMany(\App\Models\TestRun::class, 'asset_id');
+    }
+
+    /**
+     * Get the test results for this asset
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\Relation
+     */
+    public function testResults()
+    {
+        return $this->hasManyThrough(
+            \App\Models\TestResult::class,
+            \App\Models\TestRun::class,
+            'asset_id',
+            'test_run_id'
+        );
+    }
+
+    /**
      * Establishes the asset -> location relationship
      *
      * @author [A. Gianotto] [<snipe@snipe.net>]

--- a/app/Models/TestAudit.php
+++ b/app/Models/TestAudit.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
+
+class TestAudit extends SnipeModel
+{
+    use HasFactory;
+
+    public $timestamps = false;
+
+    protected $table = 'test_audits';
+
+    protected $fillable = [
+        'auditable_type',
+        'auditable_id',
+        'user_id',
+        'field',
+        'before',
+        'after',
+        'created_at',
+    ];
+
+    protected $casts = [
+        'created_at' => 'datetime',
+    ];
+
+    public function auditable(): MorphTo
+    {
+        return $this->morphTo();
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/app/Models/TestResult.php
+++ b/app/Models/TestResult.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\MorphMany;
+
+class TestResult extends SnipeModel
+{
+    use HasFactory;
+
+    protected $table = 'test_results';
+
+    protected $fillable = [
+        'test_run_id',
+        'test_type_id',
+        'status',
+        'note',
+    ];
+
+    public function run(): BelongsTo
+    {
+        return $this->belongsTo(TestRun::class, 'test_run_id');
+    }
+
+    public function type(): BelongsTo
+    {
+        return $this->belongsTo(TestType::class, 'test_type_id');
+    }
+
+    public function audits(): MorphMany
+    {
+        return $this->morphMany(TestAudit::class, 'auditable');
+    }
+}

--- a/app/Models/TestRun.php
+++ b/app/Models/TestRun.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\MorphMany;
+
+class TestRun extends SnipeModel
+{
+    use HasFactory;
+
+    protected $table = 'test_runs';
+
+    protected $fillable = [
+        'asset_id',
+        'user_id',
+        'started_at',
+        'finished_at',
+    ];
+
+    protected $casts = [
+        'started_at' => 'datetime',
+        'finished_at' => 'datetime',
+    ];
+
+    public function asset(): BelongsTo
+    {
+        return $this->belongsTo(Asset::class);
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function results(): HasMany
+    {
+        return $this->hasMany(TestResult::class, 'test_run_id');
+    }
+
+    public function audits(): MorphMany
+    {
+        return $this->morphMany(TestAudit::class, 'auditable');
+    }
+}

--- a/app/Models/TestType.php
+++ b/app/Models/TestType.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+
+class TestType extends SnipeModel
+{
+    use HasFactory;
+
+    protected $table = 'test_types';
+
+    protected $fillable = [
+        'name',
+        'slug',
+        'tooltip',
+    ];
+
+    public function results()
+    {
+        return $this->hasMany(TestResult::class, 'test_type_id');
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -582,6 +582,31 @@ class User extends SnipeModel implements AuthenticatableContract, AuthorizableCo
         return $this->hasMany(\App\Models\Asset::class, 'id')->withTrashed();
     }
 
+    /**
+     * Get the test runs for this user
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\Relation
+     */
+    public function testRuns()
+    {
+        return $this->hasMany(\App\Models\TestRun::class, 'user_id');
+    }
+
+    /**
+     * Get the test results for this user
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\Relation
+     */
+    public function testResults()
+    {
+        return $this->hasManyThrough(
+            \App\Models\TestResult::class,
+            \App\Models\TestRun::class,
+            'user_id',
+            'test_run_id'
+        );
+    }
+
 
 
     /**

--- a/database/factories/TestAuditFactory.php
+++ b/database/factories/TestAuditFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\TestAudit;
+use App\Models\TestResult;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class TestAuditFactory extends Factory
+{
+    protected $model = TestAudit::class;
+
+    public function definition()
+    {
+        return [
+            'auditable_type' => TestResult::class,
+            'auditable_id' => TestResult::factory(),
+            'user_id' => User::factory(),
+            'field' => $this->faker->word(),
+            'before' => $this->faker->sentence(),
+            'after' => $this->faker->sentence(),
+            'created_at' => now(),
+        ];
+    }
+}

--- a/database/factories/TestResultFactory.php
+++ b/database/factories/TestResultFactory.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\TestResult;
+use App\Models\TestRun;
+use App\Models\TestType;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class TestResultFactory extends Factory
+{
+    protected $model = TestResult::class;
+
+    public function definition()
+    {
+        return [
+            'test_run_id' => TestRun::factory(),
+            'test_type_id' => TestType::factory(),
+            'status' => $this->faker->randomElement(['pass', 'fail', 'skip']),
+            'note' => $this->faker->sentence(),
+        ];
+    }
+}

--- a/database/factories/TestRunFactory.php
+++ b/database/factories/TestRunFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Asset;
+use App\Models\TestRun;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class TestRunFactory extends Factory
+{
+    protected $model = TestRun::class;
+
+    public function definition()
+    {
+        $start = $this->faker->dateTimeBetween('-1 week', 'now');
+        $end = (clone $start)->modify('+'.rand(1,2).' hours');
+
+        return [
+            'asset_id' => Asset::factory(),
+            'user_id' => User::factory(),
+            'started_at' => $start,
+            'finished_at' => $end,
+        ];
+    }
+}

--- a/database/factories/TestTypeFactory.php
+++ b/database/factories/TestTypeFactory.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\TestType;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+class TestTypeFactory extends Factory
+{
+    protected $model = TestType::class;
+
+    public function definition()
+    {
+        $name = $this->faker->words(2, true);
+
+        return [
+            'name' => ucfirst($name),
+            'slug' => Str::slug($name) . '-' . Str::random(5),
+            'tooltip' => $this->faker->sentence(),
+        ];
+    }
+}

--- a/database/migrations/2025_08_12_000000_create_test_types_table.php
+++ b/database/migrations/2025_08_12_000000_create_test_types_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+
+return new class extends Migration
+{
+    public function up()
+    {
+        Schema::create('test_types', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('name');
+            $table->string('slug')->unique();
+            $table->string('tooltip')->nullable();
+            $table->timestamps();
+            $table->engine = 'InnoDB';
+            $table->charset = 'utf8mb4';
+            $table->collation = 'utf8mb4_unicode_ci';
+        });
+    }
+
+    public function down()
+    {
+        Schema::dropIfExists('test_types');
+    }
+};

--- a/database/migrations/2025_08_12_000001_create_test_runs_table.php
+++ b/database/migrations/2025_08_12_000001_create_test_runs_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+
+return new class extends Migration
+{
+    public function up()
+    {
+        Schema::create('test_runs', function (Blueprint $table) {
+            $table->increments('id');
+            $table->unsignedInteger('asset_id');
+            $table->unsignedInteger('user_id');
+            $table->timestamp('started_at')->nullable();
+            $table->timestamp('finished_at')->nullable();
+            $table->timestamps();
+            $table->engine = 'InnoDB';
+            $table->charset = 'utf8mb4';
+            $table->collation = 'utf8mb4_unicode_ci';
+
+            $table->foreign('asset_id')->references('id')->on('assets')->onDelete('cascade');
+            $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
+        });
+    }
+
+    public function down()
+    {
+        Schema::dropIfExists('test_runs');
+    }
+};

--- a/database/migrations/2025_08_12_000002_create_test_results_table.php
+++ b/database/migrations/2025_08_12_000002_create_test_results_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+
+return new class extends Migration
+{
+    public function up()
+    {
+        Schema::create('test_results', function (Blueprint $table) {
+            $table->increments('id');
+            $table->unsignedInteger('test_run_id');
+            $table->unsignedInteger('test_type_id');
+            $table->enum('status', ['pass', 'fail', 'skip']);
+            $table->text('note')->nullable();
+            $table->timestamps();
+            $table->engine = 'InnoDB';
+            $table->charset = 'utf8mb4';
+            $table->collation = 'utf8mb4_unicode_ci';
+
+            $table->foreign('test_run_id')->references('id')->on('test_runs')->onDelete('cascade');
+            $table->foreign('test_type_id')->references('id')->on('test_types')->onDelete('cascade');
+        });
+    }
+
+    public function down()
+    {
+        Schema::dropIfExists('test_results');
+    }
+};

--- a/database/migrations/2025_08_12_000003_create_test_audits_table.php
+++ b/database/migrations/2025_08_12_000003_create_test_audits_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+
+return new class extends Migration
+{
+    public function up()
+    {
+        Schema::create('test_audits', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('auditable_type');
+            $table->unsignedInteger('auditable_id');
+            $table->unsignedInteger('user_id')->nullable();
+            $table->string('field');
+            $table->text('before')->nullable();
+            $table->text('after')->nullable();
+            $table->timestamp('created_at')->useCurrent();
+            $table->engine = 'InnoDB';
+            $table->charset = 'utf8mb4';
+            $table->collation = 'utf8mb4_unicode_ci';
+
+            $table->foreign('user_id')->references('id')->on('users')->onDelete('set null');
+        });
+    }
+
+    public function down()
+    {
+        Schema::dropIfExists('test_audits');
+    }
+};


### PR DESCRIPTION
## Summary
- add migrations for test types, runs, results and audits
- introduce TestType, TestRun, TestResult and TestAudit models with relationships
- link assets and users to test runs/results and provide factories

## Testing
- `composer install` *(fails: requires ext-sodium and GitHub token)*
- `vendor/bin/phpunit` *(fails: vendor/bin/phpunit: No such file or directory)*
- `php -l app/Models/TestRun.php app/Models/TestType.php app/Models/TestResult.php app/Models/TestAudit.php`
- `php -l database/migrations/2025_08_12_000000_create_test_types_table.php database/migrations/2025_08_12_000001_create_test_runs_table.php database/migrations/2025_08_12_000002_create_test_results_table.php database/migrations/2025_08_12_000003_create_test_audits_table.php`


------
https://chatgpt.com/codex/tasks/task_e_68ad8ea4792c832d868587891988728b