### PR TITLE
Add seeders for demo assets and test types

### DIFF
--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -44,6 +44,8 @@ class DatabaseSeeder extends Seeder
         $this->call(ComponentSeeder::class);
         $this->call(ConsumableSeeder::class);
         $this->call(ActionlogSeeder::class);
+        $this->call(TestTypeSeeder::class);
+        $this->call(DemoAssetsSeeder::class);
 
 
         Artisan::call('snipeit:sync-asset-locations', ['--output' => 'all']);

--- a/database/seeders/DemoAssetsSeeder.php
+++ b/database/seeders/DemoAssetsSeeder.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Asset;
+use Illuminate\Database\Seeder;
+
+class DemoAssetsSeeder extends Seeder
+{
+    public function run()
+    {
+        for ($i = 1; $i <= 5; $i++) {
+            Asset::factory()->create([
+                'asset_tag' => sprintf('ASSET-%04d', $i),
+                'name' => 'Demo Asset ' . $i,
+            ]);
+        }
+    }
+}

--- a/database/seeders/TestTypeSeeder.php
+++ b/database/seeders/TestTypeSeeder.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+
+class TestTypeSeeder extends Seeder
+{
+    public function run()
+    {
+        DB::table('test_types')->truncate();
+
+        $types = [
+            ['name' => 'Screen', 'tooltip' => 'Placeholder tooltip for Screen'],
+            ['name' => 'Battery', 'tooltip' => 'Placeholder tooltip for Battery'],
+            ['name' => 'Keyboard', 'tooltip' => 'Placeholder tooltip for Keyboard'],
+            ['name' => 'Ports', 'tooltip' => 'Placeholder tooltip for Ports'],
+            ['name' => 'Audio', 'tooltip' => 'Placeholder tooltip for Audio'],
+            ['name' => 'Camera', 'tooltip' => 'Placeholder tooltip for Camera'],
+            ['name' => 'Microphone', 'tooltip' => 'Placeholder tooltip for Microphone'],
+            ['name' => 'Touchscreen', 'tooltip' => 'Placeholder tooltip for Touchscreen'],
+            ['name' => 'Sensors', 'tooltip' => 'Placeholder tooltip for Sensors'],
+            ['name' => 'Bluetooth', 'tooltip' => 'Placeholder tooltip for Bluetooth'],
+        ];
+
+        DB::table('test_types')->insert($types);
+    }
+}


### PR DESCRIPTION
## Summary
- seed default test types with placeholder tooltips
- seed five demo assets with sequential tags
- run new seeders from the main DatabaseSeeder

## Testing
- `composer install --ignore-platform-req=ext-sodium` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68ad8ea5c3b8832dbaa3c1e631f8253f