### PR TITLE
Add hardware test run management

### DIFF
--- a/app/Http/Controllers/TestResultController.php
+++ b/app/Http/Controllers/TestResultController.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Asset;
+use App\Models\TestRun;
+use Illuminate\Http\Request;
+
+class TestResultController extends Controller
+{
+    public function edit(Asset $asset, TestRun $testRun)
+    {
+        $this->authorize('update', Asset::class);
+        $testRun->load('results.type');
+        return view('tests.edit', compact('asset', 'testRun'));
+    }
+
+    public function update(Request $request, Asset $asset, TestRun $testRun)
+    {
+        $this->authorize('update', Asset::class);
+        foreach ($testRun->results as $result) {
+            $result->status = $request->input('status.' . $result->id);
+            $result->notes = $request->input('notes.' . $result->id);
+            $result->save();
+        }
+
+        return redirect()->route('test-runs.index', $asset->id)
+            ->with('success', trans('general.updated'));
+    }
+}

--- a/app/Http/Controllers/TestRunController.php
+++ b/app/Http/Controllers/TestRunController.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Asset;
+use App\Models\TestRun;
+use App\Models\TestType;
+use Illuminate\Http\Request;
+
+class TestRunController extends Controller
+{
+    public function index(Asset $asset)
+    {
+        $this->authorize('view', Asset::class);
+        $runs = $asset->testRuns;
+        return view('tests.index', compact('asset', 'runs'));
+    }
+
+    public function store(Request $request, Asset $asset)
+    {
+        $this->authorize('update', Asset::class);
+        $run = TestRun::create([
+            'asset_id' => $asset->id,
+            'user_id' => $request->user()->id,
+        ]);
+
+        foreach (TestType::all() as $type) {
+            $run->results()->create([
+                'test_type_id' => $type->id,
+                'status' => 'pending',
+            ]);
+        }
+
+        return redirect()->route('test-results.edit', [$asset->id, $run->id])
+            ->with('success', trans('general.created'));
+    }
+
+    public function destroy(Asset $asset, TestRun $testRun)
+    {
+        $this->authorize('update', Asset::class);
+        $testRun->delete();
+        return redirect()->route('test-runs.index', $asset->id)
+            ->with('success', trans('general.deleted'));
+    }
+}

--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -778,6 +778,17 @@ class Asset extends Depreciable
     }
 
     /**
+     * Get test runs for this asset
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\Relation
+     */
+    public function testRuns()
+    {
+        return $this->hasMany(\App\Models\TestRun::class, 'asset_id')
+            ->orderBy('created_at', 'desc');
+    }
+
+    /**
      * Get user who created the item
      *
      * @author [A. Gianotto] [<snipe@snipe.net>]

--- a/app/Models/TestResult.php
+++ b/app/Models/TestResult.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class TestResult extends Model
+{
+    protected $fillable = ['test_run_id', 'test_type_id', 'status', 'notes'];
+
+    public function run()
+    {
+        return $this->belongsTo(TestRun::class, 'test_run_id');
+    }
+
+    public function type()
+    {
+        return $this->belongsTo(TestType::class, 'test_type_id');
+    }
+}

--- a/app/Models/TestRun.php
+++ b/app/Models/TestRun.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class TestRun extends Model
+{
+    protected $fillable = ['asset_id', 'user_id'];
+
+    public function asset()
+    {
+        return $this->belongsTo(Asset::class);
+    }
+
+    public function results()
+    {
+        return $this->hasMany(TestResult::class);
+    }
+}

--- a/app/Models/TestType.php
+++ b/app/Models/TestType.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class TestType extends Model
+{
+    protected $fillable = ['name', 'description'];
+
+    public function results()
+    {
+        return $this->hasMany(TestResult::class);
+    }
+}

--- a/database/migrations/2025_08_12_000000_create_test_types_table.php
+++ b/database/migrations/2025_08_12_000000_create_test_types_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('test_types', function (Blueprint $table) {
+            $table->id();
+            $table->string('name')->unique();
+            $table->text('description')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('test_types');
+    }
+};

--- a/database/migrations/2025_08_12_000100_create_test_runs_table.php
+++ b/database/migrations/2025_08_12_000100_create_test_runs_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('test_runs', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('asset_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('test_runs');
+    }
+};

--- a/database/migrations/2025_08_12_000200_create_test_results_table.php
+++ b/database/migrations/2025_08_12_000200_create_test_results_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('test_results', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('test_run_id')->constrained('test_runs')->cascadeOnDelete();
+            $table->foreignId('test_type_id')->constrained('test_types')->cascadeOnDelete();
+            $table->string('status')->default('pending');
+            $table->text('notes')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('test_results');
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -43,6 +43,7 @@ class DatabaseSeeder extends Seeder
         $this->call(LicenseSeeder::class);
         $this->call(ComponentSeeder::class);
         $this->call(ConsumableSeeder::class);
+        $this->call(TestTypeSeeder::class);
         $this->call(ActionlogSeeder::class);
 
 

--- a/database/seeders/TestTypeSeeder.php
+++ b/database/seeders/TestTypeSeeder.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\TestType;
+
+class TestTypeSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $types = [
+            ['name' => 'External Cleaning', 'description' => 'External surfaces cleaned'],
+            ['name' => 'Internal Cleaning', 'description' => 'Internal components cleaned'],
+        ];
+
+        foreach ($types as $type) {
+            TestType::firstOrCreate(['name' => $type['name']], ['description' => $type['description']]);
+        }
+    }
+}

--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -138,6 +138,17 @@
                     </li>
 
                     <li>
+                        <a href="#tests" data-toggle="tab">
+                          <span class="hidden-lg hidden-md">
+                              <i class="fas fa-vial fa-2x"></i>
+                          </span>
+                            <span class="hidden-xs hidden-sm">Tests
+                                {!! ($asset->testRuns()->count() > 0 ) ? '<span class="badge badge-secondary">'.number_format($asset->testRuns()->count()).'</span>' : '' !!}
+                          </span>
+                        </a>
+                    </li>
+
+                    <li>
                         <a href="#maintenances" data-toggle="tab">
                           <span class="hidden-lg hidden-md">
                               <x-icon type="maintenances" class="fa-2x" />
@@ -1325,6 +1336,9 @@
                     </div><!-- /.table-responsive -->
                 </div><!-- /.tab-pane -->
 
+                    <div class="tab-pane fade" id="tests">
+                        @include('tests.index', ['asset' => $asset, 'runs' => $asset->testRuns()->get()])
+                    </div>
 
                     <div class="tab-pane fade" id="maintenances">
                         <div class="row{{($asset->maintenances->count() > 0 ) ? '' : ' hidden-print'}}">

--- a/resources/views/tests/edit.blade.php
+++ b/resources/views/tests/edit.blade.php
@@ -1,0 +1,42 @@
+@extends('layouts/default')
+
+@section('title')
+    {{ __('Edit Test Results') }}
+@endsection
+
+@section('content')
+<form method="POST" action="{{ route('test-results.update', [$asset->id, $testRun->id]) }}">
+    @csrf
+    @method('PUT')
+    <table class="table table-striped">
+        <thead>
+            <tr>
+                <th>{{ __('Test') }}</th>
+                <th>{{ __('Status') }}</th>
+                <th>{{ __('Notes') }}</th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach ($testRun->results as $result)
+                <tr>
+                    <td>
+                        {{ $result->type->name }}
+                        <i class="fas fa-info-circle" data-toggle="tooltip" title="{{ $result->type->description }}"></i>
+                    </td>
+                    <td>
+                        <select name="status[{{ $result->id }}]" class="form-control" data-toggle="tooltip" title="{{ __('Set status') }}">
+                            <option value="pass" @selected($result->status=='pass')>{{ __('Pass') }}</option>
+                            <option value="fail" @selected($result->status=='fail')>{{ __('Fail') }}</option>
+                            <option value="pending" @selected($result->status=='pending')>{{ __('Pending') }}</option>
+                        </select>
+                    </td>
+                    <td>
+                        <input type="text" name="notes[{{ $result->id }}]" value="{{ $result->notes }}" class="form-control" data-toggle="tooltip" title="{{ __('Add notes') }}">
+                    </td>
+                </tr>
+            @endforeach
+        </tbody>
+    </table>
+    <button type="submit" class="btn btn-primary">{{ trans('button.save') }}</button>
+</form>
+@endsection

--- a/resources/views/tests/index.blade.php
+++ b/resources/views/tests/index.blade.php
@@ -1,0 +1,30 @@
+<div class="mb-3 text-right">
+    <form method="POST" action="{{ route('test-runs.store', $asset->id) }}">
+        @csrf
+        <button type="submit" class="btn btn-primary">{{ __('Start New Run') }}</button>
+    </form>
+</div>
+
+<table class="table table-striped">
+    <thead>
+        <tr>
+            <th>{{ __('Date') }}</th>
+            <th>{{ __('Actions') }}</th>
+        </tr>
+    </thead>
+    <tbody>
+        @foreach ($runs as $run)
+            <tr>
+                <td>{{ $run->created_at }}</td>
+                <td>
+                    <a href="{{ route('test-results.edit', [$asset->id, $run->id]) }}" class="btn btn-default btn-sm">{{ trans('button.edit') }}</a>
+                    <form method="POST" action="{{ route('test-runs.destroy', [$asset->id, $run->id]) }}" style="display:inline">
+                        @csrf
+                        @method('DELETE')
+                        <button class="btn btn-danger btn-sm" type="submit">{{ trans('button.delete') }}</button>
+                    </form>
+                </td>
+            </tr>
+        @endforeach
+    </tbody>
+</table>

--- a/routes/web/hardware.php
+++ b/routes/web/hardware.php
@@ -5,6 +5,8 @@ use App\Http\Controllers\Assets\AssetsController;
 use App\Http\Controllers\Assets\BulkAssetsController;
 use App\Http\Controllers\Assets\AssetCheckoutController;
 use App\Http\Controllers\Assets\AssetCheckinController;
+use App\Http\Controllers\TestRunController;
+use App\Http\Controllers\TestResultController;
 use App\Models\Setting;
 use Tabuna\Breadcrumbs\Trail;
 use Illuminate\Support\Facades\Route;
@@ -159,6 +161,18 @@ Route::group(
             'bulksave',
             [BulkAssetsController::class, 'update']
         )->name('hardware/bulksave');
+
+        // Asset tests
+        Route::get('{asset}/tests', [TestRunController::class, 'index'])
+            ->name('test-runs.index');
+        Route::post('{asset}/tests', [TestRunController::class, 'store'])
+            ->name('test-runs.store');
+        Route::delete('{asset}/tests/{testRun}', [TestRunController::class, 'destroy'])
+            ->name('test-runs.destroy');
+        Route::get('{asset}/tests/{testRun}/results/edit', [TestResultController::class, 'edit'])
+            ->name('test-results.edit');
+        Route::put('{asset}/tests/{testRun}/results', [TestResultController::class, 'update'])
+            ->name('test-results.update');
 
         // Bulk checkout / checkin
         Route::get('bulkcheckout', [BulkAssetsController::class, 'showCheckout'])


### PR DESCRIPTION
## Summary
- Add Tests tab on asset view to show and manage test runs
- Implement controllers, models, migrations, and views for test runs and results
- Seed default external and internal cleaning test types

## Testing
- `composer install --no-interaction --no-progress --ignore-platform-req=ext-sodium` (fails: CONNECT tunnel failed, response 403)
- `vendor/bin/phpunit` (fails: No such file or directory)


------
https://chatgpt.com/codex/tasks/task_e_68ad8ead9ce8832d8f2c37d6a91bf21d