### PR TITLE
Add QR asset scanning route and bundle

### DIFF
--- a/app/Http/Controllers/ScanController.php
+++ b/app/Http/Controllers/ScanController.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Http\Controllers;
+
+class ScanController extends Controller
+{
+    /**
+     * Display the asset scanning page.
+     *
+     * @return \Illuminate\Contracts\View\View
+     */
+    public function index()
+    {
+        return view('scan.index');
+    }
+}

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
         "jquery-validation": "^1.21.0",
         "jquery.iframe-transport": "^1.0.0",
         "jspdf-autotable": "^5.0.2",
+        "jsqr": "^1.4.0",
         "less": "^4.2.2",
         "less-loader": "^6.0",
         "list.js": "^1.5.0",

--- a/resources/assets/js/scan.js
+++ b/resources/assets/js/scan.js
@@ -1,0 +1,49 @@
+import jsQR from 'jsqr';
+
+const video = document.getElementById('scan-video');
+const assetInput = document.getElementById('asset-tag');
+const form = document.getElementById('scan-manual');
+
+form.addEventListener('submit', (e) => {
+    e.preventDefault();
+    const tag = assetInput.value.trim();
+    if (tag) {
+        window.location.href = `/assets/${encodeURIComponent(tag)}`;
+    }
+});
+
+function startScan() {
+    if (!navigator.mediaDevices) {
+        return;
+    }
+
+    navigator.mediaDevices.getUserMedia({ video: { facingMode: 'environment' } })
+        .then(stream => {
+            video.srcObject = stream;
+            video.setAttribute('playsinline', true);
+            video.play();
+            requestAnimationFrame(tick);
+        })
+        .catch(err => {
+            console.error('Unable to access camera', err);
+        });
+}
+
+function tick() {
+    if (video.readyState === video.HAVE_ENOUGH_DATA) {
+        const canvas = document.createElement('canvas');
+        canvas.height = video.videoHeight;
+        canvas.width = video.videoWidth;
+        const context = canvas.getContext('2d');
+        context.drawImage(video, 0, 0, canvas.width, canvas.height);
+        const imageData = context.getImageData(0, 0, canvas.width, canvas.height);
+        const code = jsQR(imageData.data, canvas.width, canvas.height);
+        if (code) {
+            window.location.href = `/assets/${encodeURIComponent(code.data)}`;
+            return;
+        }
+    }
+    requestAnimationFrame(tick);
+}
+
+startScan();

--- a/resources/views/scan/index.blade.php
+++ b/resources/views/scan/index.blade.php
@@ -1,0 +1,25 @@
+@extends('layouts/default')
+
+@section('title')
+{{ __('Scan Assets') }}
+@parent
+@stop
+
+@section('content')
+<div class="row">
+    <div class="col-md-12 text-center">
+        <video id="scan-video" style="width:100%;max-width:400px;" autoplay></video>
+        <form id="scan-manual" class="form-inline" style="margin-top:15px;">
+            <div class="form-group">
+                <label class="sr-only" for="asset-tag">{{ trans('general.asset_tag') }}</label>
+                <input type="text" class="form-control" id="asset-tag" placeholder="{{ trans('general.asset_tag') }}">
+            </div>
+            <button type="submit" class="btn btn-primary">Go</button>
+        </form>
+    </div>
+</div>
+@stop
+
+@section('moar_scripts')
+<script src="{{ url(mix('js/dist/scan.js')) }}"></script>
+@stop

--- a/routes/web.php
+++ b/routes/web.php
@@ -20,6 +20,7 @@ use App\Http\Controllers\NotesController;
 use App\Http\Controllers\ProfileController;
 use App\Http\Controllers\ReportTemplatesController;
 use App\Http\Controllers\ReportsController;
+use App\Http\Controllers\ScanController;
 use App\Http\Controllers\SettingsController;
 use App\Http\Controllers\StatuslabelsController;
 use App\Http\Controllers\SuppliersController;
@@ -78,18 +79,23 @@ Route::group(['middleware' => 'auth'], function () {
 
     /*
     * Depreciations
-     */
+    */
     Route::resource('depreciations', DepreciationsController::class);
 
     /*
     * Status Labels
-     */
+    */
     Route::resource('statuslabels', StatuslabelsController::class);
 
     /*
     * Departments
     */
     Route::resource('departments', DepartmentsController::class);
+
+    /*
+    * Asset scanner
+    */
+    Route::get('scan', [ScanController::class, 'index'])->name('scan');
 });
 
 /*

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -145,3 +145,5 @@ mix
         ],
         'public/js/dist/bootstrap-table.js'
  ).version();
+
+mix.js('./resources/assets/js/scan.js', 'public/js/dist/scan.js').version();


### PR DESCRIPTION
## Summary
- add `/scan` route handled by `ScanController`
- implement scan page with video preview and manual tag entry
- include jsQR-based scanner script and bundle via webpack mix
- fix route imports and indentation after resolving merge conflicts

## Testing
- `composer install` *(fails: ext-sodium missing)*
- `apt-get update` *(fails: repository 403 Forbidden)*
- `php artisan test` *(fails: vendor autoload missing)*
- `npm install jsqr@^1.4.0 --save` *(fails: 403 Forbidden)*
- `npm run production` *(fails: can't resolve jsqr module)*

------
https://chatgpt.com/codex/tasks/task_e_68ad8eb74074832d9ed436a1f64bf7fe