### PR TITLE
Rename TestResult relations for clarity

### DIFF
--- a/app/Models/TestResult.php
+++ b/app/Models/TestResult.php
@@ -19,12 +19,12 @@ class TestResult extends SnipeModel
         'note',
     ];
 
-    public function run(): BelongsTo
+    public function testRun(): BelongsTo
     {
         return $this->belongsTo(TestRun::class, 'test_run_id');
     }
 
-    public function type(): BelongsTo
+    public function testType(): BelongsTo
     {
         return $this->belongsTo(TestType::class, 'test_type_id');
     }


### PR DESCRIPTION
## Summary
- rename `run()` relation to `testRun()`
- rename `type()` relation to `testType()`

## Testing
- `php -l app/Models/TestResult.php`
- `composer install --ignore-platform-req=ext-sodium` *(fails: missing GitHub token)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ad9ee2ab64832daaf9520936f2d20d