### PR TITLE
Add PHPDoc comments for testing models

### DIFF
--- a/app/Models/TestResult.php
+++ b/app/Models/TestResult.php
@@ -6,6 +6,12 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
 
+/**
+ * Stores the outcome of a single test within a run.
+ *
+ * Each result belongs to a specific test run and test type and may have
+ * multiple audit records.
+ */
 class TestResult extends SnipeModel
 {
     use HasFactory;
@@ -19,16 +25,25 @@ class TestResult extends SnipeModel
         'note',
     ];
 
+    /**
+     * Test run this result is associated with.
+     */
     public function run(): BelongsTo
     {
         return $this->belongsTo(TestRun::class, 'test_run_id');
     }
 
+    /**
+     * Type of test this result represents.
+     */
     public function type(): BelongsTo
     {
         return $this->belongsTo(TestType::class, 'test_type_id');
     }
 
+    /**
+     * Audit log entries for changes to this result.
+     */
     public function audits(): MorphMany
     {
         return $this->morphMany(TestAudit::class, 'auditable');

--- a/app/Models/TestRun.php
+++ b/app/Models/TestRun.php
@@ -7,6 +7,12 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
 
+/**
+ * Represents a collection of tests executed on an asset.
+ *
+ * A test run belongs to an asset and the user who performed it and contains
+ * many individual test results and audit records.
+ */
 class TestRun extends SnipeModel
 {
     use HasFactory;
@@ -25,21 +31,33 @@ class TestRun extends SnipeModel
         'finished_at' => 'datetime',
     ];
 
+    /**
+     * Asset the tests were run against.
+     */
     public function asset(): BelongsTo
     {
         return $this->belongsTo(Asset::class);
     }
 
+    /**
+     * User who performed the test run.
+     */
     public function user(): BelongsTo
     {
         return $this->belongsTo(User::class);
     }
 
+    /**
+     * Individual results captured during the run.
+     */
     public function results(): HasMany
     {
         return $this->hasMany(TestResult::class, 'test_run_id');
     }
 
+    /**
+     * Audit log entries for the test run.
+     */
     public function audits(): MorphMany
     {
         return $this->morphMany(TestAudit::class, 'auditable');

--- a/app/Models/TestType.php
+++ b/app/Models/TestType.php
@@ -3,7 +3,14 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 
+/**
+ * Defines a kind of diagnostic test that can be executed.
+ *
+ * Test types describe how a test should be interpreted and are referenced by
+ * many test results.
+ */
 class TestType extends SnipeModel
 {
     use HasFactory;
@@ -16,7 +23,10 @@ class TestType extends SnipeModel
         'tooltip',
     ];
 
-    public function results()
+    /**
+     * Results that have been recorded for this test type.
+     */
+    public function results(): HasMany
     {
         return $this->hasMany(TestResult::class, 'test_type_id');
     }


### PR DESCRIPTION
## Summary
- document TestResult with run, type, and audit relationships
- document TestRun with asset, user, result, and audit relationships
- document TestType and its results relationship

## Testing
- `php -l app/Models/TestResult.php`
- `php -l app/Models/TestRun.php`
- `php -l app/Models/TestType.php`
- `./vendor/bin/phpunit` *(fails: No such file or directory)*
- `composer install --no-interaction --no-progress` *(fails: missing ext-sodium and repeated 403 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ad9ee3e1d4832d9425a2cbade10b5c