### PR TITLE
Validate test result inputs before saving

### DIFF
--- a/app/Http/Controllers/TestResultController.php
+++ b/app/Http/Controllers/TestResultController.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\TestResult;
+use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
+use Illuminate\Http\RedirectResponse;
+
+class TestResultController extends Controller
+{
+    public function store(Request $request): RedirectResponse
+    {
+        $validated = $request->validate([
+            'status' => ['required', Rule::in(['pass', 'fail', 'pending'])],
+            'notes' => 'nullable|string',
+        ]);
+
+        $result = new TestResult();
+        $result->status = $validated['status'];
+        $result->note = $validated['notes'] ?? null;
+        $result->save();
+
+        return redirect()->back()->with('success', trans('general.test_result_saved'));
+    }
+}


### PR DESCRIPTION
## Summary
- add TestResultController with validation for status and notes

## Testing
- `composer install --no-interaction --no-progress --ignore-platform-req=ext-sodium` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68adaf365d28832d8d2aa7063012153e