### PR TITLE
chore: disable FKs when seeding test types

### DIFF
--- a/database/seeders/TestTypeSeeder.php
+++ b/database/seeders/TestTypeSeeder.php
@@ -4,12 +4,15 @@ namespace Database\Seeders;
 
 use Illuminate\Database\Seeder;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
 
 class TestTypeSeeder extends Seeder
 {
     public function run()
     {
+        Schema::disableForeignKeyConstraints();
         DB::table('test_types')->truncate();
+        Schema::enableForeignKeyConstraints();
 
         $types = [
             ['name' => 'Screen', 'tooltip' => 'Placeholder tooltip for Screen'],


### PR DESCRIPTION
## Summary
- wrap `test_types` truncation with FK constraint disable/enable during seeding

## Testing
- `composer install --no-interaction --no-progress --no-scripts` *(fails: ext-sodium missing)*
- `apt-get update` *(fails: repository 403)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*


------
https://chatgpt.com/codex/tasks/task_e_68adb5cc3910832da22de570f8f17e24