### PR TITLE
Use asset instance for test authorization

### DIFF
--- a/app/Http/Controllers/TestResultController.php
+++ b/app/Http/Controllers/TestResultController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\Asset;
 use App\Models\TestResult;
 use Illuminate\Http\Request;
 use Illuminate\Validation\Rule;
@@ -9,8 +10,10 @@ use Illuminate\Http\RedirectResponse;
 
 class TestResultController extends Controller
 {
-    public function store(Request $request): RedirectResponse
+    public function store(Request $request, Asset $asset): RedirectResponse
     {
+        $this->authorize('update', $asset);
+
         $validated = $request->validate([
             'status' => ['required', Rule::in(['pass', 'fail', 'pending'])],
             'notes' => 'nullable|string',
@@ -21,6 +24,7 @@ class TestResultController extends Controller
         $result->note = $validated['notes'] ?? null;
         $result->save();
 
-        return redirect()->back()->with('success', trans('general.test_result_saved'));
+        return redirect()->route('test-runs.index', ['asset' => $asset->id])
+            ->with('success', trans('general.test_result_saved'));
     }
 }

--- a/app/Http/Controllers/TestRunController.php
+++ b/app/Http/Controllers/TestRunController.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Asset;
+use App\Models\TestRun;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+
+class TestRunController extends Controller
+{
+    public function store(Request $request, Asset $asset): RedirectResponse
+    {
+        $this->authorize('update', $asset);
+
+        $run = new TestRun();
+        $run->asset()->associate($asset);
+        $run->user()->associate($request->user());
+        $run->save();
+
+        return redirect()->route('test-runs.index', ['asset' => $asset->id])
+            ->with('success', trans('general.test_run_created'));
+    }
+}


### PR DESCRIPTION
## Summary
- Authorize updates using the actual asset for test runs and results
- Redirect test run and result actions with explicit asset route parameters

## Testing
- `phpunit` *(fails: command not found)*
- `composer test` *(fails: Command "test" is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68adb5ce1cc8832dae141d986cb2fde5