### PR TITLE
Use singular note for test results

### DIFF
--- a/app/Http/Controllers/TestResultController.php
+++ b/app/Http/Controllers/TestResultController.php
@@ -13,12 +13,12 @@ class TestResultController extends Controller
     {
         $validated = $request->validate([
             'status' => ['required', Rule::in(['pass', 'fail', 'pending'])],
-            'notes' => 'nullable|string',
+            'note' => 'nullable|string',
         ]);
 
         $result = new TestResult();
         $result->status = $validated['status'];
-        $result->note = $validated['notes'] ?? null;
+        $result->note = $validated['note'] ?? null;
         $result->save();
 
         return redirect()->back()->with('success', trans('general.test_result_saved'));

--- a/app/Models/TestResult.php
+++ b/app/Models/TestResult.php
@@ -11,6 +11,8 @@ use Illuminate\Database\Eloquent\Relations\MorphMany;
  *
  * Each result belongs to a specific test run and test type and may have
  * multiple audit records.
+ *
+ * @property string|null $note Note captured during the test run.
  */
 class TestResult extends SnipeModel
 {

--- a/database/migrations/2025_08_12_020000_create_test_results_table.php
+++ b/database/migrations/2025_08_12_020000_create_test_results_table.php
@@ -11,7 +11,7 @@ return new class extends Migration {
             $table->id();
             $table->foreignId('test_run_id')->constrained('test_runs')->onDelete('cascade');
             $table->string('status');
-            $table->text('details')->nullable();
+            $table->text('note')->nullable();
             $table->timestamps();
         });
     }


### PR DESCRIPTION
## Summary
- Standardize test result note naming across code and schema
- Validate and save `note` field via controller

## Testing
- `php -l app/Http/Controllers/TestResultController.php`
- `php -l app/Models/TestResult.php`
- `php -l database/migrations/2025_08_12_020000_create_test_results_table.php`
- `composer install` *(fails: ext-sodium missing)*
- `composer install --ignore-platform-req=ext-sodium` *(fails: GitHub 403 on package download)*


------
https://chatgpt.com/codex/tasks/task_e_68adb5c704ec832d8c1559ee62057128