### PR TITLE
Normalize test model relationships

### DIFF
--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -890,16 +890,6 @@ class Asset extends Depreciable
     }
 
     /**
-     * Get the test runs for this asset
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\Relation
-     */
-    public function testRuns()
-    {
-        return $this->hasMany(\App\Models\TestRun::class, 'asset_id');
-    }
-
-    /**
      * Get the test results for this asset
      *
      * @return \Illuminate\Database\Eloquent\Relations\Relation

--- a/app/Models/TestResult.php
+++ b/app/Models/TestResult.php
@@ -33,17 +33,7 @@ class TestResult extends SnipeModel
         return $this->belongsTo(TestRun::class, 'test_run_id');
     }
 
-    public function run()
-    {
-        return $this->belongsTo(TestRun::class, 'test_run_id');
-    }
-
-    public function testType(): BelongsTo
-    {
-        return $this->belongsTo(TestType::class, 'test_type_id');
-    }
-
-    public function type()
+    public function type(): BelongsTo
     {
         return $this->belongsTo(TestType::class, 'test_type_id');
     }

--- a/app/Models/TestRun.php
+++ b/app/Models/TestRun.php
@@ -40,11 +40,6 @@ class TestRun extends SnipeModel
         return $this->belongsTo(Asset::class);
     }
 
-    public function asset()
-    {
-        return $this->belongsTo(Asset::class);
-    }
-
     /**
      * User who performed the test run.
      */
@@ -59,11 +54,6 @@ class TestRun extends SnipeModel
     public function results(): HasMany
     {
         return $this->hasMany(TestResult::class, 'test_run_id');
-    }
-
-    public function results()
-    {
-        return $this->hasMany(TestResult::class);
     }
 
     /**

--- a/app/Models/TestType.php
+++ b/app/Models/TestType.php
@@ -32,9 +32,4 @@ class TestType extends SnipeModel
     {
         return $this->hasMany(TestResult::class, 'test_type_id');
     }
-
-    public function results()
-    {
-        return $this->hasMany(TestResult::class);
-    }
 }

--- a/tests/Unit/TestRelationshipsTest.php
+++ b/tests/Unit/TestRelationshipsTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\Asset;
+use App\Models\TestRun;
+use App\Models\TestResult;
+use App\Models\TestType;
+use Tests\TestCase;
+
+class TestRelationshipsTest extends TestCase
+{
+    public function test_test_run_asset_relationship()
+    {
+        $asset = Asset::factory()->create();
+        $run = TestRun::factory()->create(['asset_id' => $asset->id]);
+
+        $this->assertTrue($run->asset->is($asset));
+    }
+
+    public function test_test_run_results_relationship()
+    {
+        $run = TestRun::factory()->create();
+        $result = TestResult::factory()->create(['test_run_id' => $run->id]);
+
+        $this->assertTrue($run->results->first()->is($result));
+    }
+
+    public function test_test_result_test_run_relationship()
+    {
+        $run = TestRun::factory()->create();
+        $result = TestResult::factory()->create(['test_run_id' => $run->id]);
+
+        $this->assertTrue($result->testRun->is($run));
+    }
+
+    public function test_test_result_type_relationship()
+    {
+        $type = TestType::factory()->create();
+        $result = TestResult::factory()->create(['test_type_id' => $type->id]);
+
+        $this->assertTrue($result->type->is($type));
+    }
+
+    public function test_test_type_results_relationship()
+    {
+        $type = TestType::factory()->create();
+        $result = TestResult::factory()->create(['test_type_id' => $type->id]);
+
+        $this->assertTrue($type->results->first()->is($result));
+    }
+
+    public function test_asset_test_runs_relationship()
+    {
+        $asset = Asset::factory()->create();
+        $run = TestRun::factory()->create(['asset_id' => $asset->id]);
+
+        $this->assertTrue($asset->testRuns->first()->is($run));
+    }
+}
+


### PR DESCRIPTION
## Summary
- remove duplicate relationship methods from test models
- add unit tests for asset/run/result/type relationships

## Testing
- `composer install --no-interaction --no-progress --ignore-platform-req=ext-sodium --no-scripts`
- `vendor/bin/phpunit --testsuite Unit` *(fails: Maximum execution time of 600 seconds exceeded)*

------
https://chatgpt.com/codex/tasks/task_e_68add14c30ac832d89cf55a7419a629f