### PR TITLE
Refactor test result note field

### DIFF
--- a/app/Http/Controllers/TestResultController.php
+++ b/app/Http/Controllers/TestResultController.php
@@ -24,7 +24,7 @@ class TestResultController extends Controller
         $this->authorize('update', Asset::class);
         foreach ($testRun->results as $result) {
             $result->status = $request->input('status.' . $result->id);
-            $result->notes = $request->input('notes.' . $result->id);
+            $result->note = $request->input('note.' . $result->id);
             $result->save();
         }
 

--- a/resources/lang/en-US/tests.php
+++ b/resources/lang/en-US/tests.php
@@ -10,5 +10,5 @@ return [
     'fail' => 'Fail',
     'pending' => 'Pending',
     'set_status' => 'Set status',
-    'add_notes' => 'Add notes',
+    'add_note' => 'Add note',
 ];

--- a/resources/views/tests/edit.blade.php
+++ b/resources/views/tests/edit.blade.php
@@ -21,7 +21,7 @@
                 <tr>
                     <td>
                         {{ $result->type->name }}
-                        <i class="fas fa-info-circle" data-toggle="tooltip" title="{{ $result->type->description }}"></i>
+                        <i class="fas fa-info-circle" data-toggle="tooltip" title="{{ $result->type->tooltip }}"></i>
                     </td>
                     <td>
                         <select name="status[{{ $result->id }}]" class="form-control" data-toggle="tooltip" title="{{ trans('tests.set_status') }}">
@@ -31,7 +31,7 @@
                         </select>
                     </td>
                     <td>
-                        <input type="text" name="notes[{{ $result->id }}]" value="{{ $result->notes }}" class="form-control" data-toggle="tooltip" title="{{ trans('tests.add_notes') }}">
+                        <input type="text" name="note[{{ $result->id }}]" value="{{ $result->note }}" class="form-control" data-toggle="tooltip" title="{{ trans('tests.add_note') }}">
                     </td>
                 </tr>
             @endforeach


### PR DESCRIPTION
## Summary
- use tooltip text for test type descriptions
- track a single note per test result
- adjust test translation string for note prompt

## Testing
- `vendor/bin/phpunit` *(fails: .env.testing file does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68addc5e9d1c832d8f67e1d6bc749bb8