### PR TITLE
Align TestAudit actor reference and migration

### DIFF
--- a/app/Models/TestAudit.php
+++ b/app/Models/TestAudit.php
@@ -18,7 +18,7 @@ class TestAudit extends SnipeModel
     protected $fillable = [
         'auditable_type',
         'auditable_id',
-        'user_id',
+        'actor_id',
         'field',
         'before',
         'after',
@@ -34,9 +34,8 @@ class TestAudit extends SnipeModel
         return $this->morphTo();
     }
 
-    public function actor()
+    public function actor(): BelongsTo
     {
         return $this->belongsTo(User::class, 'actor_id');
-
     }
 }

--- a/database/factories/TestAuditFactory.php
+++ b/database/factories/TestAuditFactory.php
@@ -16,7 +16,7 @@ class TestAuditFactory extends Factory
         return [
             'auditable_type' => TestResult::class,
             'auditable_id' => TestResult::factory(),
-            'user_id' => User::factory(),
+            'actor_id' => User::factory(),
             'field' => $this->faker->word(),
             'before' => $this->faker->sentence(),
             'after' => $this->faker->sentence(),

--- a/database/migrations/2025_08_12_000003_create_test_audits_table.php
+++ b/database/migrations/2025_08_12_000003_create_test_audits_table.php
@@ -9,9 +9,8 @@ return new class extends Migration
     {
         Schema::create('test_audits', function (Blueprint $table) {
             $table->increments('id');
-            $table->string('auditable_type');
-            $table->unsignedInteger('auditable_id');
-            $table->unsignedInteger('user_id')->nullable();
+            $table->morphs('auditable');
+            $table->unsignedInteger('actor_id')->nullable();
             $table->string('field');
             $table->text('before')->nullable();
             $table->text('after')->nullable();
@@ -20,7 +19,7 @@ return new class extends Migration
             $table->charset = 'utf8mb4';
             $table->collation = 'utf8mb4_unicode_ci';
 
-            $table->foreign('user_id')->references('id')->on('users')->onDelete('set null');
+            $table->foreign('actor_id')->references('id')->on('users')->onDelete('set null');
         });
     }
 


### PR DESCRIPTION
## Summary
- switch TestAudit relation to `actor_id`
- use `morphs('auditable')` in test audits migration
- update factory and model for `actor_id`

## Testing
- `php artisan migrate --database=sqlite --path=database/migrations/2025_08_12_000003_create_test_audits_table.php --force`
- `vendor/bin/phpunit --filter TestAudit` *(fails: RuntimeException: .env.testing file does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68addb0e2a74832daf15fd737b105f01