### PR TITLE
Authorize test controllers and auto-seed results

### DIFF
--- a/app/Http/Controllers/TestResultController.php
+++ b/app/Http/Controllers/TestResultController.php
@@ -6,7 +6,6 @@ use App\Models\Asset;
 use App\Models\TestRun;
 use App\Models\TestResult;
 use Illuminate\Http\Request;
-use Illuminate\Validation\Rule;
 use Illuminate\Http\RedirectResponse;
 
 class TestResultController extends Controller
@@ -14,14 +13,14 @@ class TestResultController extends Controller
     
     public function edit(Asset $asset, TestRun $testRun)
     {
-        $this->authorize('update', Asset::class);
+        $this->authorize('update', $asset);
         $testRun->load('results.type');
         return view('tests.edit', compact('asset', 'testRun'));
     }
 
     public function update(Request $request, Asset $asset, TestRun $testRun)
     {
-        $this->authorize('update', Asset::class);
+        $this->authorize('update', $asset);
         foreach ($testRun->results as $result) {
             $result->status = $request->input('status.' . $result->id);
             $result->note = $request->input('note.' . $result->id);
@@ -30,23 +29,5 @@ class TestResultController extends Controller
 
         return redirect()->route('test-runs.index', $asset->id)
             ->with('success', trans('general.updated'));
-    }
-
-public function store(Request $request, Asset $asset): RedirectResponse
-{
-        $this->authorize('update', $asset);
-
-        $validated = $request->validate([
-            'status' => ['required', Rule::in(['pass', 'fail', 'pending'])],
-            'note' => 'nullable|string',
-        ]);
-
-        $result = new TestResult();
-        $result->status = $validated['status'];
-        $result->note = $validated['note'] ?? null;
-        $result->save();
-
-        return redirect()->route('test-runs.index', ['asset' => $asset->id])
-            ->with('success', trans('general.test_result_saved'));
     }
 }


### PR DESCRIPTION
## Summary
- authorize test runs and results against the actual asset
- create pending test result entries for all test types when a run is saved
- drop unused TestResultController::store

## Testing
- `vendor/bin/phpunit` *(fails: .env.testing missing, later connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68addeeb0068832d84a5270479356291