### PR TITLE
chore: remove unused barcode import

### DIFF
--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -8,7 +8,6 @@ use App\Models\Setting;
 use App\Models\User;
 use App\Models\Ldap;
 use App\Services\Saml;
-use Com\Tecnick\Barcode\Barcode;
 use Google2FA;
 use Illuminate\Foundation\Auth\ThrottlesLogins;
 use Illuminate\Http\Request;


### PR DESCRIPTION
## Summary
- remove unused Barcode import from LoginController

## Testing
- `php artisan lint` *(fails: vendor/autoload.php not found)*
- `php -l app/Http/Controllers/Auth/LoginController.php`


------
https://chatgpt.com/codex/tasks/task_e_68ade2ad4150832d9054828fb4814b3a