### PR TITLE
Use Str slug for QR label path

### DIFF
--- a/app/Services/QrLabelService.php
+++ b/app/Services/QrLabelService.php
@@ -9,6 +9,7 @@ use BaconQrCode\Renderer\Image\ImagickImageBackEnd;
 use BaconQrCode\Renderer\RendererStyle\RendererStyle;
 use BaconQrCode\Writer;
 use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
 use TCPDF;
 
 class QrLabelService
@@ -96,7 +97,7 @@ class QrLabelService
 
     protected function path(Asset $asset, string $format): string
     {
-        return $this->directory.'/qr-'.str_slug($asset->asset_tag).'.'.$format;
+        return $this->directory.'/qr-'.Str::slug($asset->asset_tag).'.'.$format;
     }
 }
 

--- a/tests/Unit/QrLabelServiceTest.php
+++ b/tests/Unit/QrLabelServiceTest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\Asset;
+use App\Services\QrLabelService;
+use Tests\TestCase;
+use function Livewire\invade;
+
+class QrLabelServiceTest extends TestCase
+{
+    public function test_path_generates_expected_filenames(): void
+    {
+        $asset = new Asset(['asset_tag' => 'My Asset Tag']);
+        $service = new QrLabelService();
+
+        $this->assertSame('labels/qr-my-asset-tag.png', invade($service)->path($asset, 'png'));
+        $this->assertSame('labels/qr-my-asset-tag.pdf', invade($service)->path($asset, 'pdf'));
+    }
+}


### PR DESCRIPTION
## Summary
- import `Illuminate\Support\Str` and use `Str::slug` for QR label filenames
- add unit test for `QrLabelService::path`

## Testing
- `vendor/bin/phpunit`
- `vendor/bin/phpunit tests/Unit/QrLabelServiceTest.php`
- `vendor/bin/phpcs app/Services/QrLabelService.php tests/Unit/QrLabelServiceTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68ade28b29b4832db474e686a1ae6909