### PR TITLE
Refine hardware seeding and demo data

### DIFF
--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -45,7 +45,6 @@ class DatabaseSeeder extends Seeder
         $this->call(TestTypeSeeder::class);
         $this->call(ActionlogSeeder::class);
         $this->call(RolePermissionSeeder::class);
-        $this->call(TestTypeSeeder::class);
         $this->call(DemoAssetsSeeder::class);
 
 

--- a/database/seeders/DemoAssetsSeeder.php
+++ b/database/seeders/DemoAssetsSeeder.php
@@ -2,60 +2,61 @@
 
 namespace Database\Seeders;
 
-
-use App\Helpers\Helper;
 use App\Models\Asset;
-use App\Models\Setting;
+use App\Models\AssetModel;
+use App\Models\TestType;
+use App\Models\User;
+use App\Services\QrLabelService;
 use Illuminate\Database\Seeder;
 use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Str;
 
 class DemoAssetsSeeder extends Seeder
 {
     public function run(): void
     {
-        $settings = Setting::first();
+        $demoAssets = [
+            ['asset_tag' => 'ASSET-0001', 'model' => 'Macbook Pro 13"'],
+            ['asset_tag' => 'ASSET-0002', 'model' => 'Macbook Air'],
+            ['asset_tag' => 'ASSET-0003', 'model' => 'Surface'],
+            ['asset_tag' => 'ASSET-0004', 'model' => 'iPad'],
+            ['asset_tag' => 'ASSET-0005', 'model' => 'iPhone 12'],
+        ];
 
-        foreach (Asset::all() as $asset) {
+        $user = User::first();
+        $testType = TestType::first();
+        $labelService = app(QrLabelService::class);
+
+        foreach ($demoAssets as $data) {
+            $model = AssetModel::where('name', $data['model'])->first();
+            $asset = Asset::factory()->create([
+                'asset_tag' => $data['asset_tag'],
+                'name' => $data['model'],
+                'model_id' => $model?->id ?? AssetModel::factory()->create(['name' => $data['model']])->id,
+            ]);
+
             $testRunId = DB::table('test_runs')->insertGetId([
                 'asset_id' => $asset->id,
-                'run_name' => 'Initial Run',
+                'user_id' => $user?->id,
+                'started_at' => now(),
+                'finished_at' => now(),
                 'created_at' => now(),
                 'updated_at' => now(),
             ]);
 
             DB::table('test_results')->insert([
                 'test_run_id' => $testRunId,
-                'result_name' => 'Boot Diagnostics',
+                'test_type_id' => $testType?->id,
                 'status' => 'pass',
+                'note' => 'Initial test run',
                 'created_at' => now(),
                 'updated_at' => now(),
             ]);
 
-            if ($settings && $settings->label2_2d_type !== 'none') {
-                $size = Helper::barcodeDimensions($settings->label2_2d_type);
-                $barcodeDir = public_path('/uploads/barcodes');
-                if (! is_dir($barcodeDir)) {
-                    mkdir($barcodeDir, 0755, true);
-                }
-
-                $qrFile = $barcodeDir.'/qr-'.Str::slug($asset->asset_tag).'-'.Str::slug((string) $asset->id).'.png';
-
-                if (! file_exists($qrFile)) {
-                    $barcode = new \Com\Tecnick\Barcode\Barcode();
-                    $barcodeObj = $barcode->getBarcodeObj(
-                        $settings->label2_2d_type,
-                        route('hardware.show', $asset->id),
-                        $size['height'],
-                        $size['width'],
-                        'black',
-                        [-2, -2, -2, -2]
-                    );
-                    file_put_contents($qrFile, $barcodeObj->getPngData());
-                }
+            try {
+                $labelService->generate($asset);
+            } catch (\Throwable $e) {
+                // Ignore QR generation errors (e.g. missing imagick)
             }
         }
     }
 }
-
-

--- a/database/seeders/TestTypeSeeder.php
+++ b/database/seeders/TestTypeSeeder.php
@@ -28,6 +28,8 @@ class TestTypeSeeder extends Seeder
             ['name' => 'Touchscreen', 'tooltip' => 'Placeholder tooltip for Touchscreen', 'slug' => 'touchscreen'],
             ['name' => 'Sensors', 'tooltip' => 'Placeholder tooltip for Sensors', 'slug' => 'sensors'],
             ['name' => 'Bluetooth', 'tooltip' => 'Placeholder tooltip for Bluetooth', 'slug' => 'bluetooth'],
+            ['name' => 'Wi-Fi', 'tooltip' => 'Placeholder tooltip for Wi-Fi', 'slug' => 'wi-fi'],
+            ['name' => 'Cellular', 'tooltip' => 'Placeholder tooltip for Cellular', 'slug' => 'cellular'],
         ];
 
         foreach ($types as $type) {


### PR DESCRIPTION
## Summary
- remove duplicate TestTypeSeeder call
- expand TestTypeSeeder to include Wi-Fi and Cellular types
- seed demo assets with test runs, results, and QR labels

## Testing
- `php artisan migrate --force`
- `php artisan db:seed --force`


------
https://chatgpt.com/codex/tasks/task_e_68ade246f150832da248c08bdfe51049