### PR TITLE
Use NVT status for test results

### DIFF
--- a/app/Http/Controllers/TestResultController.php
+++ b/app/Http/Controllers/TestResultController.php
@@ -22,7 +22,10 @@ class TestResultController extends Controller
     {
         $this->authorize('update', $asset);
         foreach ($testRun->results as $result) {
-            $result->status = $request->input('status.' . $result->id);
+            $status = $request->input('status.' . $result->id);
+            if (in_array($status, TestResult::STATUSES, true)) {
+                $result->status = $status;
+            }
             $result->note = $request->input('note.' . $result->id);
             $result->save();
         }

--- a/app/Http/Controllers/TestRunController.php
+++ b/app/Http/Controllers/TestRunController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use App\Models\Asset;
 use App\Models\TestRun;
 use App\Models\TestType;
+use App\Models\TestResult;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 
@@ -29,7 +30,7 @@ class TestRunController extends Controller
         foreach (TestType::pluck('id') as $typeId) {
             $run->results()->create([
                 'test_type_id' => $typeId,
-                'status' => 'pending',
+                'status' => TestResult::STATUS_NVT,
                 'note' => null,
             ]);
         }

--- a/app/Models/TestResult.php
+++ b/app/Models/TestResult.php
@@ -19,6 +19,19 @@ class TestResult extends SnipeModel
 {
     use HasFactory;
 
+    public const STATUS_PASS = 'pass';
+    public const STATUS_FAIL = 'fail';
+    public const STATUS_NVT  = 'nvt';
+
+    /**
+     * Allowed status values for a test result.
+     */
+    public const STATUSES = [
+        self::STATUS_PASS,
+        self::STATUS_FAIL,
+        self::STATUS_NVT,
+    ];
+
     protected $table = 'test_results';
 
     protected $fillable = [

--- a/database/migrations/2025_08_12_000002_create_test_results_table.php
+++ b/database/migrations/2025_08_12_000002_create_test_results_table.php
@@ -11,7 +11,7 @@ return new class extends Migration
             $table->increments('id');
             $table->unsignedInteger('test_run_id');
             $table->unsignedInteger('test_type_id');
-            $table->enum('status', ['pass', 'fail', 'skip']);
+            $table->enum('status', ['pass', 'fail', 'nvt']);
             $table->text('note')->nullable();
             $table->timestamps();
             $table->engine = 'InnoDB';

--- a/resources/lang/en-US/tests.php
+++ b/resources/lang/en-US/tests.php
@@ -8,7 +8,7 @@ return [
     'start_new_run' => 'Start New Run',
     'pass' => 'Pass',
     'fail' => 'Fail',
-    'pending' => 'Pending',
+    'nvt' => 'Not Verified',
     'set_status' => 'Set status',
     'add_note' => 'Add note',
 ];

--- a/resources/views/tests/edit.blade.php
+++ b/resources/views/tests/edit.blade.php
@@ -27,7 +27,7 @@
                         <select name="status[{{ $result->id }}]" class="form-control" data-toggle="tooltip" title="{{ trans('tests.set_status') }}">
                             <option value="pass" @selected($result->status=='pass')>{{ trans('tests.pass') }}</option>
                             <option value="fail" @selected($result->status=='fail')>{{ trans('tests.fail') }}</option>
-                            <option value="pending" @selected($result->status=='pending')>{{ trans('tests.pending') }}</option>
+                            <option value="nvt" @selected($result->status=='nvt')>{{ trans('tests.nvt') }}</option>
                         </select>
                     </td>
                     <td>


### PR DESCRIPTION
## Summary
- replace old "pending"/"skip" statuses with `nvt` and add constants
- default test run results to `nvt` and validate allowed statuses
- update views and translations to show `pass`, `fail` and `nvt`

## Testing
- `composer install --no-interaction --no-progress --ignore-platform-req=ext-sodium`
- `./vendor/bin/phpunit` *(fails: .env.testing file does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68ae0e936fdc832dbae24fda71c979e2