### PR TITLE
feat: add asset testing workflow

### DIFF
--- a/app/Http/Controllers/AssetTestController.php
+++ b/app/Http/Controllers/AssetTestController.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Asset;
+use App\Models\AssetTest;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Http\JsonResponse;
+use Illuminate\View\View;
+
+class AssetTestController extends Controller
+{
+    public function index(Request $request, Asset $asset)
+    {
+        $this->authorize('view', $asset);
+        $tests = $asset->tests()->get();
+        if ($request->wantsJson()) {
+            return response()->json($tests);
+        }
+        return view('tests.index', compact('asset', 'tests'));
+    }
+
+    public function create(Asset $asset): View
+    {
+        $this->authorize('update', $asset);
+        return view('tests.create', ['asset' => $asset, 'test' => new AssetTest]);
+    }
+
+    public function store(Request $request, Asset $asset): RedirectResponse|JsonResponse
+    {
+        $this->authorize('update', $asset);
+        $data = $request->validate([
+            'performed_at' => ['required', 'date'],
+            'status' => ['required', 'string', 'max:191'],
+            'needs_cleaning' => ['sometimes', 'boolean'],
+            'notes' => ['nullable', 'string'],
+        ]);
+        $data['created_by'] = $request->user()->id;
+        $test = $asset->tests()->create($data);
+        $test->logCreate('asset test created');
+        if ($request->wantsJson()) {
+            return response()->json($test, 201);
+        }
+        return redirect()->route('asset-tests.index', $asset->id)
+            ->with('success', trans('general.created'));
+    }
+
+    public function edit(Asset $asset, AssetTest $test): View
+    {
+        $this->authorize('update', $asset);
+        return view('tests.create', compact('asset', 'test'));
+    }
+
+    public function update(Request $request, Asset $asset, AssetTest $test): RedirectResponse|JsonResponse
+    {
+        $this->authorize('update', $asset);
+        $data = $request->validate([
+            'performed_at' => ['required', 'date'],
+            'status' => ['required', 'string', 'max:191'],
+            'needs_cleaning' => ['sometimes', 'boolean'],
+            'notes' => ['nullable', 'string'],
+        ]);
+        $data['updated_by'] = $request->user()->id;
+        $test->update($data);
+        $test->log()->create([
+            'created_by' => $request->user()->id,
+            'note' => 'asset test updated'
+        ])->logaction('update');
+        if ($request->wantsJson()) {
+            return response()->json($test);
+        }
+        return redirect()->route('asset-tests.index', $asset->id)
+            ->with('success', trans('general.updated'));
+    }
+
+    public function destroy(Request $request, Asset $asset, AssetTest $test): RedirectResponse|JsonResponse
+    {
+        $this->authorize('update', $asset);
+        $test->log()->create([
+            'created_by' => $request->user()->id,
+            'note' => 'asset test deleted'
+        ])->logaction('delete');
+        $test->delete();
+        if ($request->wantsJson()) {
+            return response()->json([], 204);
+        }
+        return redirect()->route('asset-tests.index', $asset->id)
+            ->with('success', trans('general.deleted'));
+    }
+
+    public function repeatForm(Asset $asset, AssetTest $test): View
+    {
+        $this->authorize('update', $asset);
+        return view('tests.repeat', compact('asset', 'test'));
+    }
+
+    public function repeat(Request $request, Asset $asset, AssetTest $test): RedirectResponse|JsonResponse
+    {
+        $this->authorize('update', $asset);
+        $new = $asset->tests()->create([
+            'performed_at' => now(),
+            'status' => $test->status,
+            'needs_cleaning' => $test->needs_cleaning,
+            'notes' => $test->notes,
+            'created_by' => $request->user()->id,
+        ]);
+        $new->logCreate('asset test repeated');
+        if ($request->wantsJson()) {
+            return response()->json($new, 201);
+        }
+        return redirect()->route('asset-tests.index', $asset->id)
+            ->with('success', trans('general.created'));
+    }
+}

--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -9,6 +9,7 @@ use App\Http\Traits\UniqueUndeletedTrait;
 use App\Models\Traits\Acceptable;
 use App\Models\Traits\HasUploads;
 use App\Models\Traits\Searchable;
+use App\Models\AssetTest;
 use App\Presenters\Presentable;
 use App\Presenters\AssetPresenter;
 use Carbon\Carbon;
@@ -786,6 +787,15 @@ class Asset extends Depreciable
     {
         return $this->hasMany(\App\Models\TestRun::class, 'asset_id')
             ->orderBy('created_at', 'desc');
+    }
+
+    /**
+     * Asset-specific tests.
+     */
+    public function tests()
+    {
+        return $this->hasMany(AssetTest::class)
+            ->orderBy('performed_at', 'desc');
     }
 
     /**

--- a/app/Models/AssetTest.php
+++ b/app/Models/AssetTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class AssetTest extends SnipeModel
+{
+    use HasFactory;
+    use SoftDeletes;
+    use Loggable;
+
+    protected $table = 'asset_tests';
+
+    protected $fillable = [
+        'asset_id',
+        'performed_at',
+        'status',
+        'needs_cleaning',
+        'notes',
+        'created_by',
+        'updated_by',
+    ];
+
+    protected $casts = [
+        'performed_at' => 'datetime',
+        'needs_cleaning' => 'boolean',
+    ];
+
+    public function asset(): BelongsTo
+    {
+        return $this->belongsTo(Asset::class)->withTrashed();
+    }
+
+    public function creator(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'created_by')->withTrashed();
+    }
+
+    public function updater(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'updated_by')->withTrashed();
+    }
+}

--- a/database/migrations/2024_06_01_000001_create_asset_tests_table.php
+++ b/database/migrations/2024_06_01_000001_create_asset_tests_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('asset_tests', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('asset_id')->constrained('assets')->onDelete('cascade');
+            $table->dateTime('performed_at');
+            $table->string('status');
+            $table->boolean('needs_cleaning')->default(false);
+            $table->text('notes')->nullable();
+            $table->foreignId('created_by')->nullable()->constrained('users')->nullOnDelete();
+            $table->foreignId('updated_by')->nullable()->constrained('users')->nullOnDelete();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('asset_tests');
+    }
+};

--- a/resources/lang/en-US/tests.php
+++ b/resources/lang/en-US/tests.php
@@ -11,4 +11,7 @@ return [
     'nvt' => 'Not Verified',
     'set_status' => 'Set status',
     'add_note' => 'Add note',
+    'needs_cleaning' => 'Needs Cleaning',
+    'repeat' => 'Repeat',
+    'repeat_confirm' => 'Repeat this test using the previous values?',
 ];

--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -48,6 +48,12 @@
             </div>
         @endif
 
+        @if (optional($asset->tests()->first())->needs_cleaning)
+            <div class="col-md-12">
+                <span class="badge badge-warning">{{ trans('tests.needs_cleaning') }}</span>
+            </div>
+        @endif
+
         <div class="col-md-12">
             <div class="nav-tabs-custom">
                 <ul class="nav nav-tabs hidden-print">

--- a/resources/views/settings/general.blade.php
+++ b/resources/views/settings/general.blade.php
@@ -247,7 +247,8 @@
                                 <div class="col-md-8">
                                     <x-input.textarea
                                             name="test_tooltips"
-                                            :value="old('test_tooltips', json_encode($setting->test_tooltips, JSON_PRETTY_PRINT))"/>
+                                            :value="old('test_tooltips', json_encode($setting->test_tooltips, JSON_PRETTY_PRINT))"
+                                            placeholder='{"status":"Tooltip text"}'/>
                                     <p class="help-block">{{ trans('admin/settings/general.test_tooltips_help') }}</p>
                                     {!! $errors->first('test_tooltips', '<span class="alert-msg">:message</span>') !!}
                                 </div>

--- a/resources/views/tests/create.blade.php
+++ b/resources/views/tests/create.blade.php
@@ -1,0 +1,34 @@
+@extends('layouts/default')
+
+@section('title')
+    {{ trans('tests.test') }}
+@endsection
+
+@section('content')
+@php($tooltips = \App\Models\Setting::getSettings()->test_tooltips ?? [])
+<form method="POST" action="{{ isset($test->id) ? route('asset-tests.update', [$asset->id, $test->id]) : route('asset-tests.store', $asset->id) }}">
+    @csrf
+    @if(isset($test->id))
+        @method('PUT')
+    @endif
+    <div class="form-group">
+        <label for="performed_at">{{ trans('general.date') }}</label>
+        <input type="date" class="form-control" name="performed_at" value="{{ old('performed_at', optional($test->performed_at)->format('Y-m-d')) }}" data-toggle="tooltip" title="{{ $tooltips['performed_at'] ?? '' }}">
+    </div>
+    <div class="form-group">
+        <label for="status">{{ trans('general.status') }}</label>
+        <input type="text" class="form-control" name="status" value="{{ old('status', $test->status) }}" data-toggle="tooltip" title="{{ $tooltips['status'] ?? '' }}">
+    </div>
+    <div class="form-group" data-toggle="tooltip" title="{{ $tooltips['needs_cleaning'] ?? '' }}">
+        <label>
+            <input type="checkbox" name="needs_cleaning" value="1" {{ old('needs_cleaning', $test->needs_cleaning) ? 'checked' : '' }}>
+            {{ trans('tests.needs_cleaning') }}
+        </label>
+    </div>
+    <div class="form-group">
+        <label for="notes">{{ trans('general.notes') }}</label>
+        <textarea class="form-control" name="notes" data-toggle="tooltip" title="{{ $tooltips['notes'] ?? '' }}">{{ old('notes', $test->notes) }}</textarea>
+    </div>
+    <button type="submit" class="btn btn-primary">{{ trans('button.save') }}</button>
+</form>
+@endsection

--- a/resources/views/tests/index.blade.php
+++ b/resources/views/tests/index.blade.php
@@ -1,30 +1,45 @@
-<div class="mb-3 text-right">
-    <form method="POST" action="{{ route('test-runs.store', $asset->id) }}">
-        @csrf
-        <button type="submit" class="btn btn-primary">{{ trans('tests.start_new_run') }}</button>
-    </form>
-</div>
+@extends('layouts/default')
 
+@section('title')
+    {{ trans('tests.tests') }}
+@endsection
+
+@section('content')
+<div class="mb-3 text-right">
+    <a href="{{ route('asset-tests.create', $asset->id) }}" class="btn btn-primary">{{ trans('button.add') }}</a>
+</div>
 <table class="table table-striped">
     <thead>
         <tr>
             <th>{{ trans('general.date') }}</th>
+            <th>{{ trans('general.status') }}</th>
+            <th>{{ trans('tests.needs_cleaning') }}</th>
+            <th>{{ trans('general.notes') }}</th>
             <th>{{ trans('table.actions') }}</th>
         </tr>
     </thead>
     <tbody>
-        @foreach ($runs as $run)
+        @foreach ($tests as $test)
             <tr>
-                <td>{{ $run->created_at }}</td>
+                <td>{{ $test->performed_at }}</td>
+                <td>{{ $test->status }}</td>
                 <td>
-                    <a href="{{ route('test-results.edit', [$asset->id, $run->id]) }}" class="btn btn-default btn-sm">{{ trans('button.edit') }}</a>
-                    <form method="POST" action="{{ route('test-runs.destroy', [$asset->id, $run->id]) }}" style="display:inline">
+                    @if ($test->needs_cleaning)
+                        <span class="badge badge-warning">{{ trans('tests.needs_cleaning') }}</span>
+                    @endif
+                </td>
+                <td>{{ $test->notes }}</td>
+                <td>
+                    <a href="{{ route('asset-tests.edit', [$asset->id, $test->id]) }}" class="btn btn-default btn-sm">{{ trans('button.edit') }}</a>
+                    <form method="POST" action="{{ route('asset-tests.destroy', [$asset->id, $test->id]) }}" style="display:inline">
                         @csrf
                         @method('DELETE')
                         <button class="btn btn-danger btn-sm" type="submit">{{ trans('button.delete') }}</button>
                     </form>
+                    <a href="{{ route('asset-tests.repeat.form', [$asset->id, $test->id]) }}" class="btn btn-warning btn-sm">{{ trans('tests.repeat') }}</a>
                 </td>
             </tr>
         @endforeach
     </tbody>
 </table>
+@endsection

--- a/resources/views/tests/repeat.blade.php
+++ b/resources/views/tests/repeat.blade.php
@@ -1,0 +1,13 @@
+@extends('layouts/default')
+
+@section('title')
+    {{ trans('tests.repeat') }}
+@endsection
+
+@section('content')
+<p>{{ trans('tests.repeat_confirm') }}</p>
+<form method="POST" action="{{ route('asset-tests.repeat', [$asset->id, $test->id]) }}">
+    @csrf
+    <button type="submit" class="btn btn-warning">{{ trans('tests.repeat') }}</button>
+</form>
+@endsection

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Controllers\Api;
+use App\Http\Controllers\AssetTestController;
 use Illuminate\Support\Facades\Route;
 
 
@@ -602,7 +603,7 @@ Route::group(['prefix' => 'v1', 'middleware' => ['api', 'api-throttle:api']], fu
         /**
          * Asset maintenances API routes
          */
-        Route::resource('maintenances', 
+        Route::resource('maintenances',
         Api\MaintenancesController::class,
         ['names' => [
                 'index' => 'api.maintenances.index',
@@ -615,6 +616,13 @@ Route::group(['prefix' => 'v1', 'middleware' => ['api', 'api-throttle:api']], fu
         'parameters' => ['maintenance' => 'maintenance_id'],
         ]
         ); // end assets API routes
+
+        // Asset tests API routes
+        Route::get('hardware/{asset}/asset-tests', [AssetTestController::class, 'index'])->name('api.asset-tests.index');
+        Route::post('hardware/{asset}/asset-tests', [AssetTestController::class, 'store'])->name('api.asset-tests.store');
+        Route::put('hardware/{asset}/asset-tests/{assetTest}', [AssetTestController::class, 'update'])->name('api.asset-tests.update');
+        Route::delete('hardware/{asset}/asset-tests/{assetTest}', [AssetTestController::class, 'destroy'])->name('api.asset-tests.destroy');
+        Route::post('hardware/{asset}/asset-tests/{assetTest}/repeat', [AssetTestController::class, 'repeat'])->name('api.asset-tests.repeat');
 
 
       /**

--- a/routes/web/hardware.php
+++ b/routes/web/hardware.php
@@ -7,6 +7,7 @@ use App\Http\Controllers\Assets\AssetCheckoutController;
 use App\Http\Controllers\Assets\AssetCheckinController;
 use App\Http\Controllers\TestRunController;
 use App\Http\Controllers\TestResultController;
+use App\Http\Controllers\AssetTestController;
 use App\Models\Setting;
 use Tabuna\Breadcrumbs\Trail;
 use Illuminate\Support\Facades\Route;
@@ -169,6 +170,24 @@ Route::group(
             ->name('test-results.edit');
         Route::put('{asset}/tests/{testRun}/results', [TestResultController::class, 'update'])
             ->name('test-results.update');
+
+        // Asset individual tests
+        Route::get('{asset}/asset-tests', [AssetTestController::class, 'index'])
+            ->name('asset-tests.index');
+        Route::get('{asset}/asset-tests/create', [AssetTestController::class, 'create'])
+            ->name('asset-tests.create');
+        Route::post('{asset}/asset-tests', [AssetTestController::class, 'store'])
+            ->name('asset-tests.store');
+        Route::get('{asset}/asset-tests/{assetTest}/edit', [AssetTestController::class, 'edit'])
+            ->name('asset-tests.edit');
+        Route::put('{asset}/asset-tests/{assetTest}', [AssetTestController::class, 'update'])
+            ->name('asset-tests.update');
+        Route::delete('{asset}/asset-tests/{assetTest}', [AssetTestController::class, 'destroy'])
+            ->name('asset-tests.destroy');
+        Route::get('{asset}/asset-tests/{assetTest}/repeat', [AssetTestController::class, 'repeatForm'])
+            ->name('asset-tests.repeat.form');
+        Route::post('{asset}/asset-tests/{assetTest}/repeat', [AssetTestController::class, 'repeat'])
+            ->name('asset-tests.repeat');
 
         // Bulk checkout / checkin
         Route::get('bulkcheckout', [BulkAssetsController::class, 'showCheckout'])


### PR DESCRIPTION
## Summary
- track asset-specific tests in new `asset_tests` table
- manage tests via controller, routes, and blade views
- display cleaning badge and expose test tooltips in settings

## Testing
- `composer install --no-progress --prefer-dist --no-interaction --ignore-platform-req=ext-sodium`
- `vendor/bin/phpunit --testsuite Unit --testsuite Feature` *(fails: .env.testing file does not exist)*


------
https://chatgpt.com/codex/tasks/task_e_68ae1cb8107c832d82328f7360693b33