### PR TITLE
feat: add QR label customization options

### DIFF
--- a/app/Http/Controllers/Api/LabelsController.php
+++ b/app/Http/Controllers/Api/LabelsController.php
@@ -6,6 +6,8 @@ use App\Helpers\Helper;
 use App\Http\Controllers\Controller;
 use App\Http\Transformers\LabelsTransformer;
 use App\Models\Labels\Label;
+use App\Models\Asset;
+use App\Services\QrLabelService;
 use Illuminate\Http\Request;
 use Illuminate\Support\ItemNotFoundException;
 use Illuminate\Http\JsonResponse;
@@ -66,4 +68,13 @@ class LabelsController extends Controller
         return (new LabelsTransformer)->transformLabel($label);
     }
 
+    /**
+     * Return URL for a generated QR label for an asset.
+     */
+    public function download(Request $request, Asset $asset, string $format): JsonResponse
+    {
+        $this->authorize('view', $asset);
+        $service = app(QrLabelService::class);
+        return response()->json(['url' => $service->url($asset, $format)]);
+    }
 }

--- a/app/Http/Controllers/LabelsController.php
+++ b/app/Http/Controllers/LabelsController.php
@@ -14,9 +14,10 @@ use App\Models\Setting;
 use App\Models\Supplier;
 use App\Models\User;
 use App\View\Label as LabelView;
+use App\Services\QrLabelService;
 
-class LabelsController extends Controller
-{
+    class LabelsController extends Controller
+    {
     /**
      * Returns the Label view with test data
      *
@@ -94,5 +95,15 @@ class LabelsController extends Controller
             ->with('bulkedit', false)
             ->with('count', 0);
 
+    }
+
+    /**
+     * Download a generated QR label for an asset.
+     */
+    public function download(Asset $asset, string $format)
+    {
+        $this->authorize('view', $asset);
+        $service = app(QrLabelService::class);
+        return redirect($service->url($asset, $format));
     }
 }

--- a/app/Models/Setting.php
+++ b/app/Models/Setting.php
@@ -70,6 +70,9 @@ class Setting extends Model
         'google_client_secret',
         'manager_view_enabled',
         'qr_logo_path',
+        'qr_logo',
+        'qr_text_redundancy',
+        'qr_formats',
         'label_size',
         'test_tooltips',
     ];
@@ -78,6 +81,7 @@ class Setting extends Model
         'label2_asset_logo' => 'boolean',
         'require_checkinout_notes' => 'boolean',
         'manager_view_enabled' => 'boolean',
+        'qr_text_redundancy' => 'boolean',
         'test_tooltips' => 'array',
     ];
 

--- a/app/Services/QrLabelService.php
+++ b/app/Services/QrLabelService.php
@@ -31,8 +31,8 @@ class QrLabelService
         $width = imagesx($qrImg);
         $height = imagesy($qrImg);
 
-        // canvas with space for text
-        $labelHeight = $height + 20;
+        // canvas with space for text if enabled
+        $labelHeight = $height + ($settings->qr_text_redundancy ? 20 : 0);
         $canvas = imagecreatetruecolor($width, $labelHeight);
         $white = imagecolorallocate($canvas, 255, 255, 255);
         imagefill($canvas, 0, 0, $white);
@@ -40,8 +40,9 @@ class QrLabelService
         imagedestroy($qrImg);
 
         // optional logo
-        if ($settings->label_logo && $disk->exists($settings->label_logo)) {
-            $logo = imagecreatefromstring($disk->get($settings->label_logo));
+        $logoPath = $settings->qr_logo ?: $settings->label_logo;
+        if ($logoPath && $disk->exists($logoPath)) {
+            $logo = imagecreatefromstring($disk->get($logoPath));
             $logoW = imagesx($logo);
             $logoH = imagesy($logo);
             $destW = $width * 0.3;
@@ -49,32 +50,40 @@ class QrLabelService
             imagecopyresampled($canvas, $logo, ($width - $destW) / 2, ($height - $destH) / 2, 0, 0, $destW, $destH, $logoW, $logoH);
             imagedestroy($logo);
         }
-
         // asset tag text
-        $font = 5;
         $text = $asset->asset_tag;
-        $textW = imagefontwidth($font) * strlen($text);
-        $black = imagecolorallocate($canvas, 0, 0, 0);
-        imagestring($canvas, $font, ($width - $textW) / 2, $height + 2, $text, $black);
+        if ($settings->qr_text_redundancy) {
+            $font = 5;
+            $textW = imagefontwidth($font) * strlen($text);
+            $black = imagecolorallocate($canvas, 0, 0, 0);
+            imagestring($canvas, $font, ($width - $textW) / 2, $height + 2, $text, $black);
+        }
 
         ob_start();
         imagepng($canvas);
         $pngData = ob_get_clean();
         imagedestroy($canvas);
 
-        $disk->put($this->path($asset, 'png'), $pngData);
+        $formats = array_map('trim', explode(',', $settings->qr_formats ?? 'png,pdf'));
 
-        // PDF
-        $pdf = new TCPDF();
-        $pdf->AddPage();
-        $tmp = tempnam(sys_get_temp_dir(), 'qr');
-        file_put_contents($tmp, $pngData);
-        $pdf->Image($tmp, 15, 15, 50, 50, 'PNG');
-        unlink($tmp);
-        $pdf->SetY(70);
-        $pdf->SetFont('helvetica', '', 12);
-        $pdf->Cell(0, 0, $text, 0, 1, 'C');
-        $disk->put($this->path($asset, 'pdf'), $pdf->Output('', 'S'));
+        if (in_array('png', $formats)) {
+            $disk->put($this->path($asset, 'png'), $pngData);
+        }
+
+        if (in_array('pdf', $formats)) {
+            $pdf = new TCPDF();
+            $pdf->AddPage();
+            $tmp = tempnam(sys_get_temp_dir(), 'qr');
+            file_put_contents($tmp, $pngData);
+            $pdf->Image($tmp, 15, 15, 50, 50, 'PNG');
+            unlink($tmp);
+            if ($settings->qr_text_redundancy) {
+                $pdf->SetY(70);
+                $pdf->SetFont('helvetica', '', 12);
+                $pdf->Cell(0, 0, $text, 0, 1, 'C');
+            }
+            $disk->put($this->path($asset, 'pdf'), $pdf->Output('', 'S'));
+        }
     }
 
     /**

--- a/config/settings.php
+++ b/config/settings.php
@@ -1,0 +1,6 @@
+<?php
+return [
+    'qr_logo' => env('QR_LOGO', null),
+    'qr_text_redundancy' => env('QR_TEXT_REDUNDANCY', false),
+    'qr_formats' => ['png', 'pdf'],
+];

--- a/database/migrations/2025_06_03_000001_add_qr_settings_fields_to_settings_table.php
+++ b/database/migrations/2025_06_03_000001_add_qr_settings_fields_to_settings_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('settings', function (Blueprint $table) {
+            $table->string('qr_logo')->nullable();
+            $table->boolean('qr_text_redundancy')->default(false);
+            $table->string('qr_formats')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('settings', function (Blueprint $table) {
+            $table->dropColumn(['qr_logo', 'qr_text_redundancy', 'qr_formats']);
+        });
+    }
+};

--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -439,13 +439,20 @@
                                     </div>
                                 @endif
                                 @if ($snipeSettings->qr_code=='1')
-                                    @php($qrPng = $qrLabels->url($asset))
-                                    @php($qrPdf = $qrLabels->url($asset, 'pdf'))
+                                    @php($formats = explode(',', $snipeSettings->qr_formats ?? 'png,pdf'))
+                                    @php($qrPng = in_array('png', $formats) ? $qrLabels->url($asset, 'png') : null)
+                                    @php($qrPdf = in_array('pdf', $formats) ? $qrLabels->url($asset, 'pdf') : null)
                                     <div class="col-md-12 text-center" style="padding-top: 15px;">
-                                        <img src="{{ $qrPng }}" class="img-thumbnail" style="height: 150px; width: 150px; margin-right: 10px;" alt="QR code for {{ $asset->getDisplayNameAttribute() }}">
+                                        @if($qrPng)
+                                            <img src="{{ $qrPng }}" class="img-thumbnail" style="height: 150px; width: 150px; margin-right: 10px;" alt="QR code for {{ $asset->getDisplayNameAttribute() }}">
+                                        @endif
                                         <div class="mt-2">
-                                            <a href="{{ $qrPdf }}" target="_blank" class="btn btn-default"><x-icon type="print" /> Print</a>
-                                            <a href="{{ $qrPng }}" download class="btn btn-default"><x-icon type="download" /> {{ trans('general.download') }}</a>
+                                            @if($qrPdf)
+                                                <a href="{{ $qrPdf }}" target="_blank" class="btn btn-default"><x-icon type="print" /> Print</a>
+                                            @endif
+                                            @if($qrPng)
+                                                <a href="{{ $qrPng }}" download class="btn btn-default"><x-icon type="download" /> {{ trans('general.download') }}</a>
+                                            @endif
                                         </div>
                                     </div>
                                 @endif

--- a/resources/views/labels/qr/pdf.blade.php
+++ b/resources/views/labels/qr/pdf.blade.php
@@ -1,0 +1,2 @@
+@inject('qrLabels', 'App\\Services\\QrLabelService')
+<a href="{{ $qrLabels->url($asset, 'pdf') }}" target="_blank">{{ trans('general.download') }} PDF</a>

--- a/resources/views/labels/qr/png.blade.php
+++ b/resources/views/labels/qr/png.blade.php
@@ -1,0 +1,2 @@
+@inject('qrLabels', 'App\\Services\\QrLabelService')
+<img src="{{ $qrLabels->url($asset, 'png') }}" alt="QR Code">

--- a/resources/views/settings/labels.blade.php
+++ b/resources/views/settings/labels.blade.php
@@ -20,7 +20,7 @@
         }
     </style>
 
-    <form method="POST" action="{{ route('settings.labels.save') }}" accept-charset="UTF-8" id="settingsForm" autocomplete="off" class="form-horizontal" role="form">
+    <form method="POST" action="{{ route('settings.labels.save') }}" accept-charset="UTF-8" id="settingsForm" autocomplete="off" class="form-horizontal" role="form" enctype="multipart/form-data">
     <!-- CSRF Token -->
     {{csrf_field()}}
 
@@ -258,10 +258,45 @@
 
                     @if($setting->label2_enable == 0)
                                 <!-- QR Text -->
-                                <div class="form-group{{ $errors->has('qr_text') ? ' has-error' : '' }}">
+                                  <div class="form-group{{ $errors->has('qr_text') ? ' has-error' : '' }}">
                                     <div class="col-md-3 text-right">
                                         <label for="qr_text" class="control-label">{{ trans('admin/settings/general.qr_text') }}</label>
-                                    </div>
+                                  </div>
+
+                                  <!-- QR Text Redundancy -->
+                                  <div class="form-group">
+                                      <div class="col-md-9 col-md-offset-3">
+                                          <label class="form-control">
+                                              <input type="checkbox" name="qr_text_redundancy" value="1" @checked(old('qr_text_redundancy', $setting->qr_text_redundancy)) aria-label="qr_text_redundancy" />
+                                              {{ trans('admin/settings/general.qr_text_redundancy') }}
+                                          </label>
+                                      </div>
+                                  </div>
+
+                                  <!-- QR Logo -->
+                                  <div class="form-group{{ $errors->has('qr_logo') ? ' has-error' : '' }}">
+                                      <div class="col-md-3 text-right">
+                                          <label for="qr_logo" class="control-label">{{ trans('admin/settings/general.qr_logo') }}</label>
+                                      </div>
+                                      <div class="col-md-7">
+                                          <input type="file" name="qr_logo" id="qr_logo" class="form-control" />
+                                          {!! $errors->first('qr_logo', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+                                      </div>
+                                  </div>
+
+                                  <!-- QR Formats -->
+                                  <div class="form-group">
+                                      <div class="col-md-3 text-right">
+                                          <label for="qr_formats" class="control-label">{{ trans('admin/settings/general.qr_formats') }}</label>
+                                      </div>
+                                      <div class="col-md-7">
+                                          @php($selectedFormats = explode(',', old('qr_formats', $setting->qr_formats ?? 'png,pdf')))
+                                          <select name="qr_formats[]" id="qr_formats" multiple class="form-control">
+                                              <option value="png" @selected(in_array('png', $selectedFormats))>PNG</option>
+                                              <option value="pdf" @selected(in_array('pdf', $selectedFormats))>PDF</option>
+                                          </select>
+                                      </div>
+                                  </div>
                                     <div class="col-md-7">
                                         @if ($setting->qr_code == 1)
                                             <input


### PR DESCRIPTION
## Summary
- support configurable QR label logo, text redundancy, and available formats
- expose QR label download endpoints and render links in hardware view
- add UI controls and Blade templates for QR label formats

## Testing
- `php -l config/settings.php`
- `php -l database/migrations/2025_06_03_000001_add_qr_settings_fields_to_settings_table.php`
- `php -l app/Models/Setting.php`
- `php -l app/Services/QrLabelService.php`
- `php -l app/Http/Controllers/LabelsController.php`
- `php -l app/Http/Controllers/Api/LabelsController.php`
- `composer install` *(fails: ext-sodium missing)*


------
https://chatgpt.com/codex/tasks/task_e_68ae1ece1784832d8b1434ac50e78641