### PR TITLE
Add audit logging for tests

### DIFF
--- a/app/Models/TestResult.php
+++ b/app/Models/TestResult.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use App\Models\SnipeModel;
+use App\Models\Traits\TestAuditable;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
@@ -18,6 +19,7 @@ use Illuminate\Database\Eloquent\Relations\MorphMany;
 class TestResult extends SnipeModel
 {
     use HasFactory;
+    use TestAuditable;
 
     public const STATUS_PASS = 'pass';
     public const STATUS_FAIL = 'fail';

--- a/app/Models/TestRun.php
+++ b/app/Models/TestRun.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use App\Models\SnipeModel;
+use App\Models\Traits\TestAuditable;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
@@ -17,6 +18,7 @@ use Illuminate\Database\Eloquent\Relations\MorphMany;
 class TestRun extends SnipeModel
 {
     use HasFactory;
+    use TestAuditable;
 
     protected $table = 'test_runs';
 

--- a/resources/views/tests/index.blade.php
+++ b/resources/views/tests/index.blade.php
@@ -54,4 +54,13 @@
     </tbody>
 </table>
 
+@can('viewAudit')
+    @foreach ($runs as $run)
+        @include('tests.partials.audit-history', ['auditable' => $run])
+        @foreach ($run->results as $result)
+            @include('tests.partials.audit-history', ['auditable' => $result])
+        @endforeach
+    @endforeach
+@endcan
+
 @endsection

--- a/resources/views/tests/partials/audit-history.blade.php
+++ b/resources/views/tests/partials/audit-history.blade.php
@@ -1,11 +1,11 @@
-@if(auth()->user() && (auth()->user()->isSuperUser() || auth()->user()->isAdmin()))
+@if(auth()->user() && auth()->user()->can('viewAudit') && $auditable->audits->isNotEmpty())
 <div class="card mb-3">
     <div class="card-header">{{ __('Audit History') }}</div>
     <div class="card-body p-0">
         <table class="table table-sm mb-0">
             <thead>
                 <tr>
-                    <th>{{ __('Event') }}</th>
+                    <th>{{ __('Field') }}</th>
                     <th>{{ __('Actor') }}</th>
                     <th>{{ __('Timestamp') }}</th>
                     <th>{{ __('Before') }}</th>
@@ -15,11 +15,11 @@
             <tbody>
             @foreach($auditable->audits as $audit)
                 <tr>
-                    <td>{{ $audit->event }}</td>
+                    <td>{{ $audit->field }}</td>
                     <td>{{ optional($audit->actor)->name }}</td>
                     <td>{{ $audit->created_at }}</td>
-                    <td><pre class="mb-0">{{ json_encode($audit->before, JSON_PRETTY_PRINT) }}</pre></td>
-                    <td><pre class="mb-0">{{ json_encode($audit->after, JSON_PRETTY_PRINT) }}</pre></td>
+                    <td>{{ $audit->before }}</td>
+                    <td>{{ $audit->after }}</td>
                 </tr>
             @endforeach
             </tbody>

--- a/tests/Unit/TestAuditLogsTest.php
+++ b/tests/Unit/TestAuditLogsTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\Asset;
+use App\Models\TestRun;
+use App\Models\TestResult;
+use App\Models\TestType;
+use App\Models\User;
+use Tests\TestCase;
+
+class TestAuditLogsTest extends TestCase
+{
+    public function test_audit_entries_created_for_test_run_events(): void
+    {
+        $user = User::factory()->create();
+        $asset = Asset::factory()->create();
+        $this->actingAs($user);
+
+        $run = TestRun::factory()->create([
+            'asset_id' => $asset->id,
+            'user_id' => $user->id,
+        ]);
+
+        $this->assertDatabaseHas('test_audits', [
+            'auditable_type' => TestRun::class,
+            'auditable_id' => $run->id,
+            'actor_id' => $user->id,
+            'field' => 'asset_id',
+            'before' => null,
+            'after' => (string) $asset->id,
+        ]);
+
+        $original = $run->finished_at;
+        $newFinish = now()->addHour();
+        $run->update(['finished_at' => $newFinish]);
+
+        $this->assertDatabaseHas('test_audits', [
+            'auditable_type' => TestRun::class,
+            'auditable_id' => $run->id,
+            'actor_id' => $user->id,
+            'field' => 'finished_at',
+            'before' => $original ? $original->format('Y-m-d H:i:s') : null,
+            'after' => $newFinish->format('Y-m-d H:i:s'),
+        ]);
+
+        $runId = $run->id;
+        $assetId = $asset->id;
+        $run->delete();
+
+        $this->assertDatabaseHas('test_audits', [
+            'auditable_type' => TestRun::class,
+            'auditable_id' => $runId,
+            'field' => 'asset_id',
+            'before' => (string) $assetId,
+            'after' => null,
+        ]);
+    }
+
+    public function test_audit_entry_created_for_test_result_update(): void
+    {
+        $user = User::factory()->create();
+        $asset = Asset::factory()->create();
+        $this->actingAs($user);
+
+        $run = TestRun::factory()->create([
+            'asset_id' => $asset->id,
+            'user_id' => $user->id,
+        ]);
+        $type = TestType::factory()->create();
+        $result = TestResult::factory()->create([
+            'test_run_id' => $run->id,
+            'test_type_id' => $type->id,
+            'note' => null,
+        ]);
+
+        $result->update(['note' => 'Checked']);
+
+        $this->assertDatabaseHas('test_audits', [
+            'auditable_type' => TestResult::class,
+            'auditable_id' => $result->id,
+            'actor_id' => $user->id,
+            'field' => 'note',
+            'before' => null,
+            'after' => 'Checked',
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- log per-field changes for TestRun and TestResult models into `test_audits`
- show audit history in tests tab for users with `viewAudit` permission
- add unit tests for audit logging

## Testing
- `DB_CONNECTION=sqlite vendor/bin/phpunit --filter TestAuditLogsTest`

------
https://chatgpt.com/codex/tasks/task_e_68ae2374a40c832dbe054cca3d8e7a3a