### PR TITLE
Add QR logo settings with label size and tooltips

### DIFF
--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -448,11 +448,24 @@ class SettingsController extends Controller
             }
 
             // QR logo upload
-            $setting = $request->handleImages($setting, 600, 'qr_logo_path', '', 'qr_logo_path');
+            if ($request->hasFile('qr_logo')) {
+                $file = $request->file('qr_logo');
+                $ext = $file->guessExtension();
+                $filename = 'qr_logo.' . $ext;
+                $file->storeAs('', $filename, 'public');
 
-            if ($request->input('clear_qr_logo_path') == '1') {
-                $setting = $request->deleteExistingImage($setting, '', 'qr_logo_path');
-                $setting->qr_logo_path = null;
+                if ($setting->qr_logo && $setting->qr_logo !== $filename && Storage::disk('public')->exists($setting->qr_logo)) {
+                    Storage::disk('public')->delete($setting->qr_logo);
+                }
+
+                $setting->qr_logo = $filename;
+            }
+
+            if ($request->input('clear_qr_logo') == '1') {
+                if ($setting->qr_logo && Storage::disk('public')->exists($setting->qr_logo)) {
+                    Storage::disk('public')->delete($setting->qr_logo);
+                }
+                $setting->qr_logo = null;
             }
 
             // Acceptance PDF upload

--- a/app/Http/Requests/ImageUploadRequest.php
+++ b/app/Http/Requests/ImageUploadRequest.php
@@ -39,6 +39,7 @@ class ImageUploadRequest extends Request
                 'image' => 'mimes:png,gif,jpg,jpeg,svg,bmp,svg+xml,webp,avif',
                 'avatar' => 'mimes:png,gif,jpg,jpeg,svg,bmp,svg+xml,webp,avif',
                 'favicon' => 'mimes:png,gif,jpg,jpeg,svg,bmp,svg+xml,webp,image/x-icon,image/vnd.microsoft.icon,ico',
+                'qr_logo' => 'mimes:png,gif,jpg,jpeg,svg,bmp,svg+xml,webp,avif',
             ];
     }
 

--- a/app/Http/Requests/StoreLabelSettings.php
+++ b/app/Http/Requests/StoreLabelSettings.php
@@ -49,7 +49,7 @@ class StoreLabelSettings extends FormRequest
             'labels_pagewidth'                    => 'numeric|nullable',
             'labels_pageheight'                   => 'numeric|nullable',
             'qr_text'                             => 'max:31|nullable',
-            'label_size'                          => 'nullable|in:small,medium,large',
+            'label_size'                          => 'nullable|in:dymo_89x36mm',
             'label2_template'                     => [
                 'required',
                 Rule::in($names),

--- a/app/Models/Setting.php
+++ b/app/Models/Setting.php
@@ -69,7 +69,6 @@ class Setting extends Model
         'google_client_id',
         'google_client_secret',
         'manager_view_enabled',
-        'qr_logo_path',
         'qr_logo',
         'qr_text_redundancy',
         'qr_formats',
@@ -398,6 +397,14 @@ class Setting extends Model
     public static function get_client_side_key_path()
     {
         return self::get_fresh_file_path('ldap_client_tls_key', 'ldap_client_tls.key');
+    }
+
+    /**
+     * Retrieve the public URL for the QR logo.
+     */
+    public function getQrLogoUrlAttribute(): ?string
+    {
+        return $this->qr_logo ? Storage::url($this->qr_logo) : null;
     }
 
 }

--- a/database/migrations/2025_06_03_000000_add_qr_logo_label_size_and_test_tooltips_to_settings_table.php
+++ b/database/migrations/2025_06_03_000000_add_qr_logo_label_size_and_test_tooltips_to_settings_table.php
@@ -11,7 +11,7 @@ return new class extends Migration {
     public function up(): void
     {
         Schema::table('settings', function (Blueprint $table) {
-            $table->string('qr_logo_path')->nullable();
+            $table->string('qr_logo')->nullable();
             $table->string('label_size')->nullable();
             $table->json('test_tooltips')->nullable();
         });
@@ -23,7 +23,7 @@ return new class extends Migration {
     public function down(): void
     {
         Schema::table('settings', function (Blueprint $table) {
-            $table->dropColumn(['qr_logo_path', 'label_size', 'test_tooltips']);
+            $table->dropColumn(['qr_logo', 'label_size', 'test_tooltips']);
         });
     }
 };

--- a/database/migrations/2025_06_03_000001_add_qr_settings_fields_to_settings_table.php
+++ b/database/migrations/2025_06_03_000001_add_qr_settings_fields_to_settings_table.php
@@ -11,7 +11,6 @@ return new class extends Migration {
     public function up(): void
     {
         Schema::table('settings', function (Blueprint $table) {
-            $table->string('qr_logo')->nullable();
             $table->boolean('qr_text_redundancy')->default(false);
             $table->string('qr_formats')->nullable();
         });
@@ -23,7 +22,7 @@ return new class extends Migration {
     public function down(): void
     {
         Schema::table('settings', function (Blueprint $table) {
-            $table->dropColumn(['qr_logo', 'qr_text_redundancy', 'qr_formats']);
+            $table->dropColumn(['qr_text_redundancy', 'qr_formats']);
         });
     }
 };

--- a/resources/lang/en-US/admin/settings/general.php
+++ b/resources/lang/en-US/admin/settings/general.php
@@ -84,9 +84,7 @@ return [
     'label_size'                => 'Label Size',
     'label_size_help'           => 'Choose a label size for printed labels.',
     'label_size_options'        => [
-        'small' => 'Small',
-        'medium' => 'Medium',
-        'large' => 'Large',
+        'dymo_89x36mm' => 'Dymo 89×36mm',
     ],
     'laravel'                   => 'Laravel Version',
     'ldap'                      => 'LDAP',

--- a/resources/views/partials/forms/edit/uploadLogo.blade.php
+++ b/resources/views/partials/forms/edit/uploadLogo.blade.php
@@ -35,8 +35,8 @@
 
             @if (($setting->$logoVariable!='') && (Storage::disk('public')->exists(($logoPath ?? ''). $snipeSettings->$logoVariable)))
                 <div class="pull-left" style="padding-right: 20px;">
-                    <a href="{{ Storage::disk('public')->url(e(($logoPath ?? '').$snipeSettings->$logoVariable)) }}"{!! ($logoVariable!='favicon') ? ' data-toggle="lightbox"' : '' !!} title="Existing logo">
-                        <img style="height: 80px; padding-bottom: 5px;" alt="Current logo" src="{{ Storage::disk('public')->url(e(($logoPath ?? ''). $snipeSettings->$logoVariable)) }}">
+                    <a href="{{ Storage::url(e(($logoPath ?? '').$snipeSettings->$logoVariable)) }}"{!! ($logoVariable!='favicon') ? ' data-toggle="lightbox"' : '' !!} title="Existing logo">
+                        <img style="height: 80px; padding-bottom: 5px;" alt="Current logo" src="{{ Storage::url(e(($logoPath ?? ''). $snipeSettings->$logoVariable)) }}">
                     </a>
                 </div>
             @endif

--- a/resources/views/settings/branding.blade.php
+++ b/resources/views/settings/branding.blade.php
@@ -130,10 +130,10 @@
 
                         <!-- QR Code Logo -->
                         @include('partials/forms/edit/uploadLogo', [
-                            "logoVariable" => "qr_logo_path",
+                            "logoVariable" => "qr_logo",
                             "logoId" => "uploadQrLogo",
                             "logoLabel" => trans('admin/settings/general.logo_labels.qr_logo'),
-                            "logoClearVariable" => "clear_qr_logo_path",
+                            "logoClearVariable" => "clear_qr_logo",
                             "helpBlock" => trans('general.image_filetypes_help', ['size' => Helper::file_upload_max_size_readable()]),
                         ])
 

--- a/resources/views/settings/labels.blade.php
+++ b/resources/views/settings/labels.blade.php
@@ -273,17 +273,6 @@
                                       </div>
                                   </div>
 
-                                  <!-- QR Logo -->
-                                  <div class="form-group{{ $errors->has('qr_logo') ? ' has-error' : '' }}">
-                                      <div class="col-md-3 text-right">
-                                          <label for="qr_logo" class="control-label">{{ trans('admin/settings/general.qr_logo') }}</label>
-                                      </div>
-                                      <div class="col-md-7">
-                                          <input type="file" name="qr_logo" id="qr_logo" class="form-control" />
-                                          {!! $errors->first('qr_logo', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
-                                      </div>
-                                  </div>
-
                                   <!-- QR Formats -->
                                   <div class="form-group">
                                       <div class="col-md-3 text-right">


### PR DESCRIPTION
## Summary
- allow uploading and clearing a QR code logo stored under `storage/app/public/qr_logo.*`
- support selecting predefined label size (initially "Dymo 89×36mm")
- add JSON test tooltip configuration helpers

## Testing
- `composer install --ignore-platform-req=ext-sodium`
- `vendor/bin/phpunit --testsuite=Unit` *(fails: `.env.testing file does not exist`)*

------
https://chatgpt.com/codex/tasks/task_e_68ae23884d30832d999a209a11c748c4