### PR TITLE
feat: centralize qr label generation

### DIFF
--- a/app/Http/Controllers/Api/LabelsController.php
+++ b/app/Http/Controllers/Api/LabelsController.php
@@ -68,13 +68,4 @@ class LabelsController extends Controller
         return (new LabelsTransformer)->transformLabel($label);
     }
 
-    /**
-     * Return URL for a generated QR label for an asset.
-     */
-    public function download(Request $request, Asset $asset, string $format): JsonResponse
-    {
-        $this->authorize('view', $asset);
-        $service = app(QrLabelService::class);
-        return response()->json(['url' => $service->url($asset, $format)]);
-    }
 }

--- a/app/Http/Controllers/LabelsController.php
+++ b/app/Http/Controllers/LabelsController.php
@@ -97,13 +97,4 @@ use App\Services\QrLabelService;
 
     }
 
-    /**
-     * Download a generated QR label for an asset.
-     */
-    public function download(Asset $asset, string $format)
-    {
-        $this->authorize('view', $asset);
-        $service = app(QrLabelService::class);
-        return redirect($service->url($asset, $format));
-    }
 }


### PR DESCRIPTION
## Summary
- generate asset QR labels with logos and optional tag text
- allow regenerating labels from console command
- drop legacy QR download endpoints

## Testing
- `vendor/bin/phpunit` *(fails: .env.testing file does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68ae25d94074832d83fdcfee88268070