### PR TITLE
Add asset scanning and testing permissions

### DIFF
--- a/app/Http/Controllers/AssetTestController.php
+++ b/app/Http/Controllers/AssetTestController.php
@@ -8,11 +8,13 @@ use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\JsonResponse;
 use Illuminate\View\View;
+use Illuminate\Support\Facades\Gate;
 
 class AssetTestController extends Controller
 {
     public function index(Request $request, Asset $asset)
     {
+        Gate::authorize('tests.execute');
         $this->authorize('view', $asset);
         $tests = $asset->tests()->get();
         if ($request->wantsJson()) {
@@ -23,12 +25,14 @@ class AssetTestController extends Controller
 
     public function create(Asset $asset): View
     {
+        Gate::authorize('tests.execute');
         $this->authorize('update', $asset);
         return view('tests.create', ['asset' => $asset, 'test' => new AssetTest]);
     }
 
     public function store(Request $request, Asset $asset): RedirectResponse|JsonResponse
     {
+        Gate::authorize('tests.execute');
         $this->authorize('update', $asset);
         $data = $request->validate([
             'performed_at' => ['required', 'date'],
@@ -48,12 +52,14 @@ class AssetTestController extends Controller
 
     public function edit(Asset $asset, AssetTest $test): View
     {
+        Gate::authorize('tests.execute');
         $this->authorize('update', $asset);
         return view('tests.create', compact('asset', 'test'));
     }
 
     public function update(Request $request, Asset $asset, AssetTest $test): RedirectResponse|JsonResponse
     {
+        Gate::authorize('tests.execute');
         $this->authorize('update', $asset);
         $data = $request->validate([
             'performed_at' => ['required', 'date'],
@@ -76,6 +82,7 @@ class AssetTestController extends Controller
 
     public function destroy(Request $request, Asset $asset, AssetTest $test): RedirectResponse|JsonResponse
     {
+        Gate::authorize('tests.delete');
         $this->authorize('update', $asset);
         $test->log()->create([
             'created_by' => $request->user()->id,
@@ -91,12 +98,14 @@ class AssetTestController extends Controller
 
     public function repeatForm(Asset $asset, AssetTest $test): View
     {
+        Gate::authorize('tests.execute');
         $this->authorize('update', $asset);
         return view('tests.repeat', compact('asset', 'test'));
     }
 
     public function repeat(Request $request, Asset $asset, AssetTest $test): RedirectResponse|JsonResponse
     {
+        Gate::authorize('tests.execute');
         $this->authorize('update', $asset);
         $new = $asset->tests()->create([
             'performed_at' => now(),

--- a/app/Http/Controllers/ScanController.php
+++ b/app/Http/Controllers/ScanController.php
@@ -11,6 +11,7 @@ class ScanController extends Controller
      */
     public function index()
     {
+        \Illuminate\Support\Facades\Gate::authorize('scanning');
         return view('scan.index');
     }
 }

--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -38,6 +38,7 @@ use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\URL;
 use Illuminate\Support\Facades\Validator;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
+use Illuminate\Support\Facades\Gate;
 
 /**
  * This controller handles all actions related to Settings for
@@ -353,6 +354,7 @@ class SettingsController extends Controller
         $setting->profile_edit = $request->input('profile_edit', 0);
         $setting->require_checkinout_notes = $request->input('require_checkinout_notes', 0);
         $setting->manager_view_enabled = $request->input('manager_view_enabled', 0);
+        Gate::authorize('config.qr_tooltips');
         $tooltips = $request->input('test_tooltips');
         $setting->test_tooltips = $tooltips ? json_decode($tooltips, true) : null;
 
@@ -770,6 +772,7 @@ class SettingsController extends Controller
      */
     public function getLabels() : View
     {
+        Gate::authorize('config.qr_tooltips');
         $is_gd_installed = extension_loaded('gd');
 
         return view('settings.labels')
@@ -786,6 +789,7 @@ class SettingsController extends Controller
      */
     public function postLabels(StoreLabelSettings $request) : RedirectResponse
     {
+        Gate::authorize('config.qr_tooltips');
         if (is_null($setting = Setting::getSettings())) {
             return redirect()->to('admin')->with('error', trans('admin/settings/message.update.error'));
         }

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -295,9 +295,13 @@ class AuthServiceProvider extends ServiceProvider
             return $user->hasAccess('scanning');
         });
 
-        Gate::define('tests.execute', function ($user) {
-            return $user->hasAccess('tests.execute');
-        });
+          Gate::define('tests.execute', function ($user) {
+              return $user->hasAccess('tests.execute');
+          });
+
+          Gate::define('tests.delete', function ($user) {
+              return $user->hasAccess('tests.delete');
+          });
 
         Gate::define('assets.create', function ($user) {
             return $user->hasAccess('assets.create');
@@ -307,9 +311,13 @@ class AuthServiceProvider extends ServiceProvider
             return $user->hasAccess('audits.view');
         });
 
-        Gate::define('config.manage', function ($user) {
-            return $user->hasAccess('config.manage');
-        });
+          Gate::define('config.manage', function ($user) {
+              return $user->hasAccess('config.manage');
+          });
+
+          Gate::define('config.qr_tooltips', function ($user) {
+              return $user->hasAccess('config.qr_tooltips');
+          });
 
         // This determines whether the user can edit their profile based on the setting in Admin > General
         Gate::define('self.profile', function ($user) {

--- a/config/permissions.php
+++ b/config/permissions.php
@@ -629,6 +629,12 @@ return [
             'note'       => 'Allows the user to run system tests.',
             'display'    => true,
         ],
+        [
+            'permission' => 'tests.delete',
+            'label'      => 'Delete Tests',
+            'note'       => 'Allows the user to remove test runs.',
+            'display'    => true,
+        ],
     ],
 
     'Audits' => [
@@ -645,6 +651,12 @@ return [
             'permission' => 'config.manage',
             'label'      => 'Manage Configuration',
             'note'       => 'Allows the user to modify system configuration.',
+            'display'    => true,
+        ],
+        [
+            'permission' => 'config.qr_tooltips',
+            'label'      => 'Configure QR & Tooltips',
+            'note'       => 'Allows the user to manage QR code and tooltip settings.',
             'display'    => true,
         ],
     ],

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -8,6 +8,7 @@ use Illuminate\Database\Seeder;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
+use App\Models\Group;
 
 class DatabaseSeeder extends Seeder
 {
@@ -46,6 +47,46 @@ class DatabaseSeeder extends Seeder
         $this->call(TestTypeSeeder::class);
         $this->call(ActionlogSeeder::class);
         $this->call(RolePermissionSeeder::class);
+
+        // Seed default roles with permissions
+        Group::updateOrCreate(
+            ['name' => 'Refurbisher'],
+            ['permissions' => json_encode([
+                'scanning' => 1,
+            ])]
+        );
+
+        Group::updateOrCreate(
+            ['name' => 'Senior Refurbisher'],
+            ['permissions' => json_encode([
+                'scanning'      => 1,
+                'tests.execute' => 1,
+            ])]
+        );
+
+        Group::updateOrCreate(
+            ['name' => 'Supervisor'],
+            ['permissions' => json_encode([
+                'scanning'      => 1,
+                'tests.execute' => 1,
+                'assets.create' => 1,
+                'assets.delete' => 1,
+                'tests.delete'  => 1,
+            ])]
+        );
+
+        Group::updateOrCreate(
+            ['name' => 'Admin'],
+            ['permissions' => json_encode([
+                'scanning'           => 1,
+                'tests.execute'      => 1,
+                'assets.create'      => 1,
+                'assets.delete'      => 1,
+                'tests.delete'       => 1,
+                'audits.view'        => 1,
+                'config.qr_tooltips' => 1,
+            ])]
+        );
         // Create demo assets
         $this->call(DemoAssetsSeeder::class);
 

--- a/resources/views/settings/general.blade.php
+++ b/resources/views/settings/general.blade.php
@@ -239,20 +239,22 @@
                                 </div>
                             </div>
 
-                            <!-- Test Tooltips -->
-                            <div class="form-group {{ $errors->has('test_tooltips') ? 'error' : '' }}">
-                                <div class="col-md-3">
-                                    <label for="test_tooltips">{{ trans('admin/settings/general.test_tooltips') }}</label>
+                            @can('config.qr_tooltips')
+                                <!-- Test Tooltips -->
+                                <div class="form-group {{ $errors->has('test_tooltips') ? 'error' : '' }}">
+                                    <div class="col-md-3">
+                                        <label for="test_tooltips">{{ trans('admin/settings/general.test_tooltips') }}</label>
+                                    </div>
+                                    <div class="col-md-8">
+                                        <x-input.textarea
+                                                name="test_tooltips"
+                                                :value="old('test_tooltips', json_encode($setting->test_tooltips, JSON_PRETTY_PRINT))"
+                                                placeholder='{"status":"Tooltip text"}'/>
+                                        <p class="help-block">{{ trans('admin/settings/general.test_tooltips_help') }}</p>
+                                        {!! $errors->first('test_tooltips', '<span class="alert-msg">:message</span>') !!}
+                                    </div>
                                 </div>
-                                <div class="col-md-8">
-                                    <x-input.textarea
-                                            name="test_tooltips"
-                                            :value="old('test_tooltips', json_encode($setting->test_tooltips, JSON_PRETTY_PRINT))"
-                                            placeholder='{"status":"Tooltip text"}'/>
-                                    <p class="help-block">{{ trans('admin/settings/general.test_tooltips_help') }}</p>
-                                    {!! $errors->first('test_tooltips', '<span class="alert-msg">:message</span>') !!}
-                                </div>
-                            </div>
+                            @endcan
 
                         </fieldset>
 

--- a/resources/views/settings/labels.blade.php
+++ b/resources/views/settings/labels.blade.php
@@ -155,7 +155,7 @@
 
                                 </div>
                             </div>
-                        @endif
+                @endif
                         @if($setting->label2_enable == 0)
                             @if ($is_gd_installed)
                             <!-- barcode -->
@@ -208,6 +208,7 @@
                                 </div>
                             </div>
                                 
+                @can('config.qr_tooltips')
                 @if($setting->label2_enable == 0)
 
                         <!-- qr code -->
@@ -316,6 +317,7 @@
                                     </div>
                                 </div>
 
+                @endcan
                                 <!-- Nuke barcode cache -->
                                 <div class="form-group">
                                     <div class="col-md-3 text-right">

--- a/resources/views/start/admin.blade.php
+++ b/resources/views/start/admin.blade.php
@@ -7,15 +7,21 @@
 
 @section('content')
 <div class="row">
-    <div class="col-xs-12 col-sm-6 col-md-3" style="margin-bottom: 15px;">
-        <a href="{{ route('scan') }}" class="btn btn-primary btn-block">Scan QR</a>
-    </div>
-    <div class="col-xs-12 col-sm-6 col-md-3" style="margin-bottom: 15px;">
-        <a href="{{ route('hardware.create') }}" class="btn btn-primary btn-block">New Asset</a>
-    </div>
-    <div class="col-xs-12 col-sm-6 col-md-3" style="margin-bottom: 15px;">
-        <a href="{{ route('hardware.index') }}" class="btn btn-primary btn-block">Management</a>
-    </div>
+    @can('scanning')
+        <div class="col-xs-12 col-sm-6 col-md-3" style="margin-bottom: 15px;">
+            <a href="{{ route('scan') }}" class="btn btn-primary btn-block">Scan QR</a>
+        </div>
+    @endcan
+    @can('assets.create')
+        <div class="col-xs-12 col-sm-6 col-md-3" style="margin-bottom: 15px;">
+            <a href="{{ route('hardware.create') }}" class="btn btn-primary btn-block">New Asset</a>
+        </div>
+    @endcan
+    @can('assets.delete')
+        <div class="col-xs-12 col-sm-6 col-md-3" style="margin-bottom: 15px;">
+            <a href="{{ route('hardware.index') }}" class="btn btn-primary btn-block">Management</a>
+        </div>
+    @endcan
     <div class="col-xs-12 col-sm-6 col-md-3" style="margin-bottom: 15px;">
         <a href="{{ route('users.index') }}" class="btn btn-primary btn-block">Users</a>
     </div>

--- a/resources/views/start/refurbisher.blade.php
+++ b/resources/views/start/refurbisher.blade.php
@@ -7,8 +7,10 @@
 
 @section('content')
 <div class="row">
-    <div class="col-xs-12 col-sm-6 col-md-4" style="margin-bottom: 15px;">
-        <a href="{{ route('scan') }}" class="btn btn-primary btn-block">Scan QR</a>
-    </div>
+    @can('scanning')
+        <div class="col-xs-12 col-sm-6 col-md-4" style="margin-bottom: 15px;">
+            <a href="{{ route('scan') }}" class="btn btn-primary btn-block">Scan QR</a>
+        </div>
+    @endcan
 </div>
 @stop

--- a/resources/views/start/senior-refurbisher.blade.php
+++ b/resources/views/start/senior-refurbisher.blade.php
@@ -7,11 +7,15 @@
 
 @section('content')
 <div class="row">
-    <div class="col-xs-12 col-sm-6 col-md-4" style="margin-bottom: 15px;">
-        <a href="{{ route('scan') }}" class="btn btn-primary btn-block">Scan QR</a>
-    </div>
-    <div class="col-xs-12 col-sm-6 col-md-4" style="margin-bottom: 15px;">
-        <a href="{{ route('hardware.create') }}" class="btn btn-primary btn-block">New Asset</a>
-    </div>
+    @can('scanning')
+        <div class="col-xs-12 col-sm-6 col-md-4" style="margin-bottom: 15px;">
+            <a href="{{ route('scan') }}" class="btn btn-primary btn-block">Scan QR</a>
+        </div>
+    @endcan
+    @can('assets.create')
+        <div class="col-xs-12 col-sm-6 col-md-4" style="margin-bottom: 15px;">
+            <a href="{{ route('hardware.create') }}" class="btn btn-primary btn-block">New Asset</a>
+        </div>
+    @endcan
 </div>
 @stop

--- a/resources/views/start/supervisor.blade.php
+++ b/resources/views/start/supervisor.blade.php
@@ -7,14 +7,20 @@
 
 @section('content')
 <div class="row">
-    <div class="col-xs-12 col-sm-6 col-md-4" style="margin-bottom: 15px;">
-        <a href="{{ route('scan') }}" class="btn btn-primary btn-block">Scan QR</a>
-    </div>
-    <div class="col-xs-12 col-sm-6 col-md-4" style="margin-bottom: 15px;">
-        <a href="{{ route('hardware.create') }}" class="btn btn-primary btn-block">New Asset</a>
-    </div>
-    <div class="col-xs-12 col-sm-6 col-md-4" style="margin-bottom: 15px;">
-        <a href="{{ route('hardware.index') }}" class="btn btn-primary btn-block">Management</a>
-    </div>
+    @can('scanning')
+        <div class="col-xs-12 col-sm-6 col-md-4" style="margin-bottom: 15px;">
+            <a href="{{ route('scan') }}" class="btn btn-primary btn-block">Scan QR</a>
+        </div>
+    @endcan
+    @can('assets.create')
+        <div class="col-xs-12 col-sm-6 col-md-4" style="margin-bottom: 15px;">
+            <a href="{{ route('hardware.create') }}" class="btn btn-primary btn-block">New Asset</a>
+        </div>
+    @endcan
+    @can('assets.delete')
+        <div class="col-xs-12 col-sm-6 col-md-4" style="margin-bottom: 15px;">
+            <a href="{{ route('hardware.index') }}" class="btn btn-primary btn-block">Management</a>
+        </div>
+    @endcan
 </div>
 @stop

--- a/resources/views/tests/index.blade.php
+++ b/resources/views/tests/index.blade.php
@@ -7,10 +7,12 @@
 
 @section('content')
 <div class="mb-3 text-right">
-    <form method="POST" action="{{ route('test-runs.store', $asset->id) }}" style="display:inline">
-        @csrf
-        <button type="submit" class="btn btn-primary">{{ trans('tests.start_new_run') }}</button>
-    </form>
+    @can('tests.execute')
+        <form method="POST" action="{{ route('test-runs.store', $asset->id) }}" style="display:inline">
+            @csrf
+            <button type="submit" class="btn btn-primary">{{ trans('tests.start_new_run') }}</button>
+        </form>
+    @endcan
 </div>
 
 <table class="table table-striped">
@@ -41,20 +43,24 @@
                         @endforeach
                     </ul>
                 </td>
-                <td>
-                    <a href="{{ route('test-results.edit', [$asset->id, $run->id]) }}" class="btn btn-default btn-sm">{{ trans('button.edit') }}</a>
-                    <form method="POST" action="{{ route('test-runs.destroy', [$asset->id, $run->id]) }}" style="display:inline">
-                        @csrf
-                        @method('DELETE')
-                        <button class="btn btn-danger btn-sm" type="submit">{{ trans('button.delete') }}</button>
-                    </form>
-                </td>
+                    <td>
+                        @can('tests.execute')
+                            <a href="{{ route('test-results.edit', [$asset->id, $run->id]) }}" class="btn btn-default btn-sm">{{ trans('button.edit') }}</a>
+                        @endcan
+                        @can('tests.delete')
+                            <form method="POST" action="{{ route('test-runs.destroy', [$asset->id, $run->id]) }}" style="display:inline">
+                                @csrf
+                                @method('DELETE')
+                                <button class="btn btn-danger btn-sm" type="submit">{{ trans('button.delete') }}</button>
+                            </form>
+                        @endcan
+                    </td>
             </tr>
         @endforeach
     </tbody>
 </table>
 
-@can('viewAudit')
+@can('audits.view')
     @foreach ($runs as $run)
         @include('tests.partials.audit-history', ['auditable' => $run])
         @foreach ($run->results as $result)

--- a/resources/views/tests/partials/audit-history.blade.php
+++ b/resources/views/tests/partials/audit-history.blade.php
@@ -1,4 +1,4 @@
-@if(auth()->user() && auth()->user()->can('viewAudit') && $auditable->audits->isNotEmpty())
+@if(auth()->user() && auth()->user()->can('audits.view') && $auditable->audits->isNotEmpty())
 <div class="card mb-3">
     <div class="card-header">{{ __('Audit History') }}</div>
     <div class="card-body p-0">


### PR DESCRIPTION
## Summary
- define permissions for test deletion and QR/tooltip configuration
- seed Refurbisher through Admin roles with appropriate abilities
- gate scanning, testing, and audit views in controllers and blades

## Testing
- `vendor/bin/phpunit` *(fails: .env.testing file does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68ae3089fc60832d82e5d1507643e9e3