### PR TITLE
Seed demo assets with QR codes and role accounts

### DIFF
--- a/database/seeders/DemoAssetsSeeder.php
+++ b/database/seeders/DemoAssetsSeeder.php
@@ -3,10 +3,16 @@
 namespace Database\Seeders;
 
 use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\Auth;
 use App\Models\Asset;
 use App\Models\AssetModel;
 use App\Models\Category;
 use App\Models\Manufacturer;
+use App\Models\TestRun;
+use App\Models\TestResult;
+use App\Models\TestType;
+use App\Models\User;
+use App\Services\QrLabelService;
 
 class DemoAssetsSeeder extends Seeder
 {
@@ -20,6 +26,11 @@ class DemoAssetsSeeder extends Seeder
             ['asset_tag' => 'ASSET-0005', 'name' => 'iPhone 12', 'category' => 'Mobile Phones', 'manufacturer' => 'Apple'],
         ];
 
+        $user = User::first();
+        if ($user) {
+            Auth::login($user);
+        }
+
         foreach ($assets as $data) {
             $category = Category::firstWhere('name', $data['category']);
             $manufacturer = Manufacturer::firstWhere('name', $data['manufacturer']);
@@ -32,11 +43,36 @@ class DemoAssetsSeeder extends Seeder
                 ]
             );
 
-            Asset::factory()->create([
+            $asset = Asset::factory()->create([
                 'asset_tag' => $data['asset_tag'],
-                'name' => $data['name'],
-                'model_id' => $model->id,
+                'name'       => $data['name'],
+                'model_id'   => $model->id,
             ]);
+
+            // Generate initial QR labels for the asset
+            app(QrLabelService::class)->generate($asset);
+
+            // Create a baseline test run with results
+            $run = TestRun::factory()->create([
+                'asset_id' => $asset->id,
+                'user_id'  => $user?->id,
+            ]);
+
+            $types = TestType::inRandomOrder()->take(3)->get();
+            foreach ($types as $type) {
+                $result = TestResult::factory()->create([
+                    'test_run_id' => $run->id,
+                    'test_type_id' => $type->id,
+                    'status' => TestResult::STATUS_FAIL,
+                ]);
+
+                // Update the result to log an audit entry representing an edit
+                $result->update(['status' => TestResult::STATUS_PASS]);
+            }
+        }
+
+        if ($user) {
+            Auth::logout();
         }
     }
 }

--- a/database/seeders/UserSeeder.php
+++ b/database/seeders/UserSeeder.php
@@ -112,6 +112,59 @@ class UserSeeder extends Seeder
                 'last_name' => 'User',
             ]);
 
+        User::factory()
+            ->state(new Sequence(fn($sequence) => [
+                'company_id' => $companyIds->random(),
+                'department_id' => $departmentIds->random(),
+            ]))
+            ->create([
+                'username'    => 'demo_refurbisher',
+                'email'       => 'demo_refurbisher@example.com',
+                'first_name'  => 'Demo',
+                'last_name'   => 'Refurbisher',
+                'permissions' => json_encode([
+                    'refurbisher' => 1,
+                    'scanning'    => 1,
+                ]),
+            ]);
+
+        User::factory()
+            ->state(new Sequence(fn($sequence) => [
+                'company_id' => $companyIds->random(),
+                'department_id' => $departmentIds->random(),
+            ]))
+            ->create([
+                'username'    => 'demo_senior_refurbisher',
+                'email'       => 'demo_senior_refurbisher@example.com',
+                'first_name'  => 'Demo',
+                'last_name'   => 'Senior',
+                'permissions' => json_encode([
+                    'senior-refurbisher' => 1,
+                    'scanning'           => 1,
+                    'tests.execute'      => 1,
+                ]),
+            ]);
+
+        User::factory()
+            ->state(new Sequence(fn($sequence) => [
+                'company_id' => $companyIds->random(),
+                'department_id' => $departmentIds->random(),
+            ]))
+            ->create([
+                'username'    => 'demo_supervisor',
+                'email'       => 'demo_supervisor@example.com',
+                'first_name'  => 'Demo',
+                'last_name'   => 'Supervisor',
+                'permissions' => json_encode([
+                    'supervisor'    => 1,
+                    'scanning'      => 1,
+                    'tests.execute' => 1,
+                    'assets.create' => 1,
+                    'assets.delete' => 1,
+                    'tests.delete'  => 1,
+                ]),
+            ]);
+
         $src = public_path('/img/demo/avatars/');
         $dst = 'avatars'.'/';
         $del_files = Storage::files($dst);

--- a/docs/DEMO.md
+++ b/docs/DEMO.md
@@ -1,0 +1,28 @@
+# Demo Instructions
+
+This guide walks through the demo data included with the seeders.
+
+## Populate Demo Data
+
+Run the database seeds to create demo assets, users and supporting data:
+
+```
+php artisan migrate:fresh --seed
+```
+
+This will also generate QR labels and baseline test runs for the demo assets.
+
+## Demo Accounts
+
+All demo accounts use the default password `password`.
+
+| Username | Role | Capabilities |
+|----------|------|--------------|
+| `demo_super` | Superuser | full access |
+| `demo_admin` | Admin | admin access |
+| `demo_supervisor` | Supervisor | scanning, create/delete assets and tests |
+| `demo_senior_refurbisher` | Senior Refurbisher | scanning and execute tests |
+| `demo_refurbisher` | Refurbisher | scanning |
+| `demo_user` | User | read-only asset access |
+
+Log in with these accounts to explore how permissions affect the interface and to view test run audit logs and QR labels generated for each asset.

--- a/docs/demo-guide.md
+++ b/docs/demo-guide.md
@@ -16,6 +16,9 @@ The seeders create demo accounts to showcase permissions:
 
 - **demo_super** – superuser access
 - **demo_admin** – administrative access
+- **demo_supervisor** – supervisor access with scanning and asset/test management
+- **demo_senior_refurbisher** – senior refurbisher with scanning and test execution
+- **demo_refurbisher** – refurbisher with scanning access
 - **demo_user** – read-only asset access
 
 All demo accounts use the default password `password`.


### PR DESCRIPTION
## Summary
- generate QR labels and baseline test runs for demo assets
- add demo users for refurbisher, senior refurbisher, and supervisor roles
- document running the demo and accounts in `docs/DEMO.md`

## Testing
- `vendor/bin/phpunit` *(fails: .env.testing file does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68ae331d6ea4832d9b493669730902e8