### PR TITLE
Clear test tables before seeding users

### DIFF
--- a/database/seeders/UserSeeder.php
+++ b/database/seeders/UserSeeder.php
@@ -5,6 +5,8 @@ namespace Database\Seeders;
 use App\Models\Company;
 use App\Models\Department;
 use App\Models\User;
+use App\Models\TestAudit;
+use App\Models\TestRun;
 use Illuminate\Database\Eloquent\Factories\Sequence;
 use Illuminate\Database\Seeder;
 use Illuminate\Support\Facades\Storage;
@@ -19,6 +21,8 @@ class UserSeeder extends Seeder
      */
     public function run()
     {
+        TestAudit::truncate();
+        TestRun::truncate();
         User::truncate();
 
         if (! Company::count()) {


### PR DESCRIPTION
## Summary
- clear test run and audit tables prior to seeding users to avoid foreign key violations

## Testing
- `php artisan db:seed --class=UserSeeder --force`


------
https://chatgpt.com/codex/tasks/task_e_68ae3b1c47f4832d9d8bb00be3d2b213