### PR TITLE
Clear test tables before seeding users

### DIFF
--- a/database/seeders/UserSeeder.php
+++ b/database/seeders/UserSeeder.php
@@ -5,8 +5,11 @@ namespace Database\Seeders;
 use App\Models\Company;
 use App\Models\Department;
 use App\Models\User;
+use App\Models\TestAudit;
+use App\Models\TestRun;
 use Illuminate\Database\Eloquent\Factories\Sequence;
 use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Facades\Log;
 
@@ -19,7 +22,15 @@ class UserSeeder extends Seeder
      */
     public function run()
     {
+        // Disable foreign key checks temporarily
+        DB::statement('SET FOREIGN_KEY_CHECKS=0;');
+
+        TestAudit::truncate();
+        TestRun::truncate();
         User::truncate();
+
+        // Re-enable foreign key checks
+        DB::statement('SET FOREIGN_KEY_CHECKS=1;');
 
         if (! Company::count()) {
             $this->call(CompanySeeder::class);


### PR DESCRIPTION
## Summary
- disable foreign key checks while truncating test tables before seeding users

## Testing
- `php artisan db:seed --class=UserSeeder --force` *(fails: SQLSTATE[HY000] [2002] No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ae3b1c47f4832d9d8bb00be3d2b213