### PR TITLE
Use unsigned asset ID in asset tests migration

### DIFF
--- a/database/migrations/2024_06_01_000001_create_asset_tests_table.php
+++ b/database/migrations/2024_06_01_000001_create_asset_tests_table.php
@@ -10,7 +10,8 @@ return new class extends Migration
     {
         Schema::create('asset_tests', function (Blueprint $table) {
             $table->id();
-            $table->foreignId('asset_id')->constrained('assets')->onDelete('cascade');
+            $table->unsignedInteger('asset_id');
+            $table->foreign('asset_id')->references('id')->on('assets')->onDelete('cascade');
             $table->dateTime('performed_at');
             $table->string('status');
             $table->boolean('needs_cleaning')->default(false);


### PR DESCRIPTION
## Summary
- ensure asset_tests migration uses `unsignedInteger('asset_id')` with an explicit foreign key to assets.id

## Testing
- `./vendor/bin/phpunit --filter testPermissionRequiredToViewUnacceptedAssetReport` *(fails: RuntimeException: .env.testing file does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68b009903054832da473a0c56ef1ca6f