### PR TITLE
Enable QR code defaults in Settings seeder

### DIFF
--- a/database/seeders/SettingsSeeder.php
+++ b/database/seeders/SettingsSeeder.php
@@ -36,6 +36,9 @@ class SettingsSeeder extends Seeder
         $settings->version_footer = 'on';
         $settings->support_footer = 'on';
         $settings->pwd_secure_min = '8';
+        $settings->qr_code = 1;
+        $settings->qr_text_redundancy = 0;
+        $settings->qr_formats = 'png,pdf';
         $settings->default_avatar = 'default.png';
         $settings->save();
 


### PR DESCRIPTION
## Summary
- enable QR labels by default in SettingsSeeder
- add default QR text redundancy and formats values

## Testing
- `php artisan db:seed --class=SettingsSeeder --force`
- `php artisan storage:link`
- `./vendor/bin/phpunit --testsuite=Unit` (fails: .env.testing file does not exist)

------
https://chatgpt.com/codex/tasks/task_e_68b09af63ea0832db4c0580ab0e68d7f