### PR TITLE
feat: accept agent test results

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -204,6 +204,8 @@ LIVEWIRE_URL_PREFIX=null
 AGENT_API_TOKEN=null
 # Comma separated list of IPs allowed to use the agent API
 AGENT_ALLOWED_IPS=
+# User ID to attribute agent submissions in audit logs
+AGENT_USER_ID=
 
 # --------------------------------------------
 # OPTIONAL: HASHING

--- a/.env.example
+++ b/.env.example
@@ -202,6 +202,8 @@ LIVEWIRE_URL_PREFIX=null
 # OPTIONAL: AGENT API TOKEN
 # --------------------------------------------
 AGENT_API_TOKEN=null
+# Comma separated list of IPs allowed to use the agent API
+AGENT_ALLOWED_IPS=
 
 # --------------------------------------------
 # OPTIONAL: HASHING

--- a/.env.example
+++ b/.env.example
@@ -199,6 +199,11 @@ CSV_ESCAPE_FORMULAS=true
 LIVEWIRE_URL_PREFIX=null
 
 # --------------------------------------------
+# OPTIONAL: AGENT API TOKEN
+# --------------------------------------------
+AGENT_API_TOKEN=null
+
+# --------------------------------------------
 # OPTIONAL: HASHING
 # --------------------------------------------
 HASHING_DRIVER='bcrypt'

--- a/.env.testing.example
+++ b/.env.testing.example
@@ -22,3 +22,5 @@ DB_PASSWORD=null
 # OPTIONAL: AGENT API TOKEN
 # --------------------------------------------
 AGENT_API_TOKEN=null
+# Comma separated list of IPs allowed to use the agent API
+AGENT_ALLOWED_IPS=

--- a/.env.testing.example
+++ b/.env.testing.example
@@ -24,3 +24,5 @@ DB_PASSWORD=null
 AGENT_API_TOKEN=null
 # Comma separated list of IPs allowed to use the agent API
 AGENT_ALLOWED_IPS=
+# User ID to attribute agent submissions in audit logs
+AGENT_USER_ID=null

--- a/.env.testing.example
+++ b/.env.testing.example
@@ -17,3 +17,8 @@ DB_PORT=3306
 DB_DATABASE=null
 DB_USERNAME=null
 DB_PASSWORD=null
+
+# --------------------------------------------
+# OPTIONAL: AGENT API TOKEN
+# --------------------------------------------
+AGENT_API_TOKEN=null

--- a/app/Http/Controllers/AgentTestController.php
+++ b/app/Http/Controllers/AgentTestController.php
@@ -20,17 +20,17 @@ class AgentTestController extends Controller
         }
 
         $validated = $request->validate([
-            'asset_tag' => ['required_without:asset_id', 'string'],
-            'asset_id' => ['required_without:asset_tag', 'integer', 'exists:assets,id'],
+            'asset_tag' => ['required', 'string'],
             'results' => ['required', 'array'],
             'results.*.test_slug' => ['required', 'string', 'exists:test_types,slug'],
             'results.*.status' => ['required', 'string', 'in:' . implode(',', TestResult::STATUSES)],
             'results.*.note' => ['nullable', 'string'],
         ]);
 
-        $asset = isset($validated['asset_id'])
-            ? Asset::findOrFail($validated['asset_id'])
-            : Asset::where('asset_tag', $validated['asset_tag'])->firstOrFail();
+        $asset = Asset::where('asset_tag', $validated['asset_tag'])->first();
+        if (!$asset) {
+            return response()->json(['message' => 'Asset not found'], 404);
+        }
 
         $run = new TestRun();
         $run->asset()->associate($asset);

--- a/app/Http/Controllers/AgentTestController.php
+++ b/app/Http/Controllers/AgentTestController.php
@@ -8,6 +8,7 @@ use App\Models\TestResult;
 use App\Models\TestType;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Log;
 
 class AgentTestController extends Controller
@@ -47,9 +48,17 @@ class AgentTestController extends Controller
             return response()->json(['message' => 'Asset not found'], 404);
         }
 
+        $agentUserId = config('agent.user_id');
+        if ($agentUserId) {
+            Auth::onceUsingId($agentUserId);
+        }
+
         $run = new TestRun();
         $run->asset()->associate($asset);
         $run->sku()->associate($asset->sku);
+        if ($agentUserId) {
+            $run->user_id = $agentUserId;
+        }
         $run->started_at = now();
         $run->finished_at = now();
         $run->save();
@@ -76,7 +85,7 @@ class AgentTestController extends Controller
         }
 
         $run->audits()->create([
-            'user_id' => null,
+            'user_id' => $agentUserId,
             'field' => 'source',
             'before' => null,
             'after' => 'agent',

--- a/app/Http/Controllers/AgentTestController.php
+++ b/app/Http/Controllers/AgentTestController.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Asset;
+use App\Models\TestRun;
+use App\Models\TestResult;
+use App\Models\TestType;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class AgentTestController extends Controller
+{
+    public function store(Request $request): JsonResponse
+    {
+
+        $token = $request->bearerToken();
+        if (!$token || !hash_equals(config('agent.api_token'), $token)) {
+            return response()->json(['message' => 'Unauthorized'], 401);
+        }
+
+        $validated = $request->validate([
+            'asset_tag' => ['required_without:asset_id', 'string'],
+            'asset_id' => ['required_without:asset_tag', 'integer', 'exists:assets,id'],
+            'results' => ['required', 'array'],
+            'results.*.test_slug' => ['required', 'string', 'exists:test_types,slug'],
+            'results.*.status' => ['required', 'string', 'in:' . implode(',', TestResult::STATUSES)],
+            'results.*.note' => ['nullable', 'string'],
+        ]);
+
+        $asset = isset($validated['asset_id'])
+            ? Asset::findOrFail($validated['asset_id'])
+            : Asset::where('asset_tag', $validated['asset_tag'])->firstOrFail();
+
+        $run = new TestRun();
+        $run->asset()->associate($asset);
+        $run->sku()->associate($asset->sku);
+        $run->started_at = now();
+        $run->finished_at = now();
+        $run->save();
+
+        foreach ($validated['results'] as $result) {
+            $type = TestType::where('slug', $result['test_slug'])->first();
+            $run->results()->create([
+                'test_type_id' => $type->id,
+                'status' => $result['status'],
+                'note' => $result['note'] ?? null,
+            ]);
+        }
+
+        $asset->refreshTestCompletionFlag();
+
+        return response()->json(['test_run_id' => $run->id], 201);
+    }
+}

--- a/app/Models/CompanyableTrait.php
+++ b/app/Models/CompanyableTrait.php
@@ -2,6 +2,8 @@
 
 namespace App\Models;
 
+use App\Models\CompanyableScope;
+
 trait CompanyableTrait
 {
     /**
@@ -14,12 +16,14 @@ trait CompanyableTrait
     public static function bootCompanyableTrait()
     {
         // In Version 7.0 and before locations weren't scoped by companies, so add a check for the backward compatibility setting
-        if (__CLASS__ != 'App\Models\Location') {
+        if (__CLASS__ != 'App\\Models\\Location') {
             static::addGlobalScope(new CompanyableScope);
         } else {
-            if (Setting::getSettings()->scope_locations_fmcs == 1) {
+            $settings = Setting::getSettings();
+            if ($settings && $settings->scope_locations_fmcs == 1) {
                 static::addGlobalScope(new CompanyableScope);
             }
         }
     }
 }
+

--- a/app/Models/CompanyableTrait.php
+++ b/app/Models/CompanyableTrait.php
@@ -20,7 +20,7 @@ trait CompanyableTrait
             static::addGlobalScope(new CompanyableScope);
         } else {
             $settings = Setting::getSettings();
-            if ($settings && $settings->scope_locations_fmcs == 1) {
+            if ($settings?->scope_locations_fmcs == 1) {
                 static::addGlobalScope(new CompanyableScope);
             }
         }

--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -99,6 +99,10 @@ class RouteServiceProvider extends ServiceProvider
                 });
         });
 
+        RateLimiter::for('agent', function (Request $request) {
+            return Limit::perMinute(60)->by($request->ip());
+        });
+
         // Rate limiter for forgotten password requests
         RateLimiter::for('forgotten_password', function (Request $request) {
             return Limit::perMinute(config('auth.password_reset.max_attempts_per_min'))->by(optional($request->user())->id ?: $request->ip());

--- a/config/agent.php
+++ b/config/agent.php
@@ -2,5 +2,6 @@
 
 return [
     'api_token' => env('AGENT_API_TOKEN'),
+    'allowed_ips' => array_filter(explode(',', env('AGENT_ALLOWED_IPS', ''))),
 ];
 

--- a/config/agent.php
+++ b/config/agent.php
@@ -3,5 +3,6 @@
 return [
     'api_token' => env('AGENT_API_TOKEN'),
     'allowed_ips' => array_filter(explode(',', env('AGENT_ALLOWED_IPS', ''))),
+    'user_id' => env('AGENT_USER_ID'),
 ];
 

--- a/config/agent.php
+++ b/config/agent.php
@@ -1,0 +1,6 @@
+<?php
+
+return [
+    'api_token' => env('AGENT_API_TOKEN'),
+];
+

--- a/database/migrations/2025_08_12_000001_create_test_runs_table.php
+++ b/database/migrations/2025_08_12_000001_create_test_runs_table.php
@@ -11,7 +11,7 @@ return new class extends Migration
         Schema::create('test_runs', function (Blueprint $table) {
             $table->increments('id');
             $table->unsignedInteger('asset_id');
-            $table->unsignedInteger('user_id');
+            $table->unsignedInteger('user_id')->nullable();
             $table->timestamp('started_at')->nullable();
             $table->timestamp('finished_at')->nullable();
             $table->timestamps();

--- a/docs/agent-api-token.md
+++ b/docs/agent-api-token.md
@@ -1,14 +1,19 @@
 # Agent API Token
 
-The local Windows agent must authenticate when submitting test results.
+The local Windows agent must authenticate when submitting reports such as test
+results.
 Generate a shared token and set it in the server's `.env` file:
 
 ```
 AGENT_API_TOKEN=your-secret
 ```
 
-Configure the agent to include this token in the `Authorization` header when
-calling `POST /api/v1/agent/test-results`:
+Every request must specify a `type` indicating the report being submitted. For
+now only `test_results` is supported, but additional report types (such as wipe
+certificates) may be added later.
+
+Configure the agent to include the token in the `Authorization` header when
+calling `POST /api/v1/agent/reports` with `type` set to `test_results`:
 
 ```
 Authorization: Bearer your-secret

--- a/docs/agent-api-token.md
+++ b/docs/agent-api-token.md
@@ -1,0 +1,19 @@
+# Agent API Token
+
+The local Windows agent must authenticate when submitting test results.
+Generate a shared token and set it in the server's `.env` file:
+
+```
+AGENT_API_TOKEN=your-secret
+```
+
+Configure the agent to include this token in the `Authorization` header when
+calling `POST /api/v1/agent/test-results`:
+
+```
+Authorization: Bearer your-secret
+```
+
+Requests with a missing or incorrect token will receive a `401 Unauthorized`
+response.
+

--- a/docs/agent-api-token.md
+++ b/docs/agent-api-token.md
@@ -15,7 +15,11 @@ Authorization: Bearer your-secret
 ```
 
 Requests with a missing or incorrect token will receive a `401 Unauthorized`
-response. On success, the API returns a `200 OK` with the new `test_run_id`.
-If the asset tag is unknown, a `404` is returned, and invalid payloads
-receive a `400` with error details.
+response. You may further restrict access by whitelisting specific IPs via
+`AGENT_ALLOWED_IPS=ip1,ip2` in your environment. Every submission is logged
+with the asset tag and the originating IP for audit purposes.
+
+On success, the API returns a `200 OK` with the new `test_run_id`. If the
+asset tag is unknown, a `404` is returned, and invalid payloads receive a
+`400` with error details.
 

--- a/docs/agent-api-token.md
+++ b/docs/agent-api-token.md
@@ -19,6 +19,15 @@ response. You may further restrict access by whitelisting specific IPs via
 `AGENT_ALLOWED_IPS=ip1,ip2` in your environment. Every submission is logged
 with the asset tag and the originating IP for audit purposes.
 
+If you want test runs to be attributed to a specific user in the UI and audit
+logs, create a user for the agent and expose its ID via:
+
+```
+AGENT_USER_ID=123
+```
+
+The agent test runs will then appear under that user.
+
 On success, the API returns a `200 OK` with the new `test_run_id`. If the
 asset tag is unknown, a `404` is returned, and invalid payloads receive a
 `400` with error details.

--- a/docs/agent-api-token.md
+++ b/docs/agent-api-token.md
@@ -15,5 +15,7 @@ Authorization: Bearer your-secret
 ```
 
 Requests with a missing or incorrect token will receive a `401 Unauthorized`
-response.
+response. On success, the API returns a `200 OK` with the new `test_run_id`.
+If the asset tag is unknown, a `404` is returned, and invalid payloads
+receive a `400` with error details.
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,7 +1,7 @@
 <?php
 
 use App\Http\Controllers\Api;
-use App\Http\Controllers\AgentTestController;
+use App\Http\Controllers\AgentReportController;
 use App\Http\Controllers\AssetTestController;
 use Illuminate\Support\Facades\Route;
 
@@ -625,11 +625,11 @@ Route::group(['prefix' => 'v1', 'middleware' => ['api', 'api-throttle:api']], fu
         Route::delete('hardware/{asset}/asset-tests/{assetTest}', [AssetTestController::class, 'destroy'])->name('api.asset-tests.destroy');
         Route::post('hardware/{asset}/asset-tests/{assetTest}/repeat', [AssetTestController::class, 'repeat'])->name('api.asset-tests.repeat');
 
-        // Agent-provided test results
-        Route::post('agent/test-results', [AgentTestController::class, 'store'])
+        // Agent-provided reports (currently only test results)
+        Route::post('agent/reports', [AgentReportController::class, 'store'])
             ->middleware('throttle:agent')
             ->withoutMiddleware('auth:api')
-            ->name('api.agent.test-results.store');
+            ->name('api.agent.reports.store');
 
 
       /**

--- a/routes/api.php
+++ b/routes/api.php
@@ -627,6 +627,7 @@ Route::group(['prefix' => 'v1', 'middleware' => ['api', 'api-throttle:api']], fu
 
         // Agent-provided test results
         Route::post('agent/test-results', [AgentTestController::class, 'store'])
+            ->middleware('throttle:agent')
             ->withoutMiddleware('auth:api')
             ->name('api.agent.test-results.store');
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Controllers\Api;
+use App\Http\Controllers\AgentTestController;
 use App\Http\Controllers\AssetTestController;
 use Illuminate\Support\Facades\Route;
 
@@ -623,6 +624,11 @@ Route::group(['prefix' => 'v1', 'middleware' => ['api', 'api-throttle:api']], fu
         Route::put('hardware/{asset}/asset-tests/{assetTest}', [AssetTestController::class, 'update'])->name('api.asset-tests.update');
         Route::delete('hardware/{asset}/asset-tests/{assetTest}', [AssetTestController::class, 'destroy'])->name('api.asset-tests.destroy');
         Route::post('hardware/{asset}/asset-tests/{assetTest}/repeat', [AssetTestController::class, 'repeat'])->name('api.asset-tests.repeat');
+
+        // Agent-provided test results
+        Route::post('agent/test-results', [AgentTestController::class, 'store'])
+            ->withoutMiddleware('auth:api')
+            ->name('api.agent.test-results.store');
 
 
       /**

--- a/tests/Feature/Assets/Api/AgentTestResultsTest.php
+++ b/tests/Feature/Assets/Api/AgentTestResultsTest.php
@@ -20,6 +20,7 @@ class AgentTestResultsTest extends TestCase
         $ram = TestType::factory()->create(['slug' => 'ram']);
 
         $payload = [
+            'type' => 'test_results',
             'asset_tag' => $asset->asset_tag,
             'results' => [
                 [
@@ -37,7 +38,7 @@ class AgentTestResultsTest extends TestCase
 
         Log::spy();
 
-        $this->postJson('/api/v1/agent/test-results', $payload, [
+        $this->postJson('/api/v1/agent/reports', $payload, [
             'Authorization' => 'Bearer secrettoken',
         ])->assertStatus(200)
             ->assertJsonStructure(['message', 'test_run_id']);
@@ -89,6 +90,7 @@ class AgentTestResultsTest extends TestCase
         $type = TestType::factory()->create(['slug' => 'cpu']);
 
         $payload = [
+            'type' => 'test_results',
             'asset_tag' => 'MISSING_TAG',
             'results' => [
                 [
@@ -100,7 +102,7 @@ class AgentTestResultsTest extends TestCase
 
         config(['agent.api_token' => 'secrettoken']);
 
-        $this->postJson('/api/v1/agent/test-results', $payload, [
+        $this->postJson('/api/v1/agent/reports', $payload, [
             'Authorization' => 'Bearer secrettoken',
         ])->assertStatus(404)
             ->assertJson(['message' => 'Asset not found']);
@@ -113,6 +115,7 @@ class AgentTestResultsTest extends TestCase
         TestType::factory()->create(['slug' => 'cpu']);
 
         $payload = [
+            'type' => 'test_results',
             'asset_tag' => $asset->asset_tag,
             'results' => [
                 [
@@ -124,7 +127,7 @@ class AgentTestResultsTest extends TestCase
 
         config(['agent.api_token' => 'secrettoken']);
 
-        $this->postJson('/api/v1/agent/test-results', $payload, [
+        $this->postJson('/api/v1/agent/reports', $payload, [
             'Authorization' => 'Bearer secrettoken',
         ])->assertStatus(400)
             ->assertJsonStructure(['message', 'errors']);
@@ -137,6 +140,7 @@ class AgentTestResultsTest extends TestCase
         $cpu = TestType::factory()->create(['slug' => 'cpu']);
 
         $payload = [
+            'type' => 'test_results',
             'asset_tag' => $asset->asset_tag,
             'results' => [
                 [
@@ -149,7 +153,7 @@ class AgentTestResultsTest extends TestCase
         config(['agent.api_token' => 'secrettoken']);
         config(['agent.allowed_ips' => ['10.0.0.1']]);
 
-        $this->postJson('/api/v1/agent/test-results', $payload, [
+        $this->postJson('/api/v1/agent/reports', $payload, [
             'Authorization' => 'Bearer secrettoken',
         ])->assertStatus(401)
             ->assertJson(['message' => 'Unauthorized']);

--- a/tests/Feature/Assets/Api/AgentTestResultsTest.php
+++ b/tests/Feature/Assets/Api/AgentTestResultsTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Tests\Feature\Assets\Api;
+
+use App\Models\Asset;
+use App\Models\Setting;
+use App\Models\TestResult;
+use App\Models\TestRun;
+use App\Models\TestType;
+use Tests\TestCase;
+
+class AgentTestResultsTest extends TestCase
+{
+    public function test_agent_can_submit_test_results(): void
+    {
+        Setting::factory()->create();
+
+        $asset = Asset::factory()->laptopMbp()->create(['asset_tag' => 'TAG123']);
+        $type = TestType::factory()->create(['slug' => 'cpu']);
+
+        $payload = [
+            'asset_tag' => $asset->asset_tag,
+            'results' => [
+                [
+                    'test_slug' => $type->slug,
+                    'status' => TestResult::STATUS_PASS,
+                    'note' => 'All good',
+                ],
+            ],
+        ];
+
+        config(['agent.api_token' => 'secrettoken']);
+
+        $this->postJson('/api/v1/agent/test-results', $payload, [
+            'Authorization' => 'Bearer secrettoken',
+        ])->assertStatus(201);
+
+        $run = TestRun::where('asset_id', $asset->id)->first();
+        $this->assertNotNull($run);
+
+        $this->assertDatabaseHas('test_results', [
+            'test_run_id' => $run->id,
+            'test_type_id' => $type->id,
+            'status' => TestResult::STATUS_PASS,
+            'note' => 'All good',
+        ]);
+
+        $asset->refresh();
+        $this->assertTrue((bool) $asset->tests_completed_ok);
+    }
+}

--- a/tests/Feature/Assets/Api/AgentTestResultsTest.php
+++ b/tests/Feature/Assets/Api/AgentTestResultsTest.php
@@ -12,14 +12,16 @@ class AgentTestResultsTest extends TestCase
 {
     public function test_agent_can_submit_test_results(): void
     {
+        \App\Models\User::factory()->create();
         $asset = Asset::factory()->laptopMbp()->create(['asset_tag' => 'TAG123']);
-        $type = TestType::factory()->create(['slug' => 'cpu']);
+        $cpu = TestType::factory()->create(['slug' => 'cpu']);
+        $ram = TestType::factory()->create(['slug' => 'ram']);
 
         $payload = [
             'asset_tag' => $asset->asset_tag,
             'results' => [
                 [
-                    'test_slug' => $type->slug,
+                    'test_slug' => $cpu->slug,
                     'status' => TestResult::STATUS_PASS,
                     'note' => 'All good',
                 ],
@@ -37,9 +39,16 @@ class AgentTestResultsTest extends TestCase
 
         $this->assertDatabaseHas('test_results', [
             'test_run_id' => $run->id,
-            'test_type_id' => $type->id,
+            'test_type_id' => $cpu->id,
             'status' => TestResult::STATUS_PASS,
             'note' => 'All good',
+        ]);
+
+        $this->assertDatabaseHas('test_results', [
+            'test_run_id' => $run->id,
+            'test_type_id' => $ram->id,
+            'status' => TestResult::STATUS_NVT,
+            'note' => 'Not tested by agent',
         ]);
 
         $asset->refresh();


### PR DESCRIPTION
## Summary
- allow agents to POST test results tied to an asset and create a test run
- expose `/api/v1/agent/test-results` endpoint requiring a shared bearer token
- document AGENT_API_TOKEN setup for the Windows agent

## Testing
- `composer install --prefer-dist --no-progress --ignore-platform-req=ext-sodium`
- `DB_CONNECTION=sqlite_testing php artisan test tests/Feature/Assets/Api/AgentTestResultsTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68c0a11176ec832d9197f996390bb773