### PR TITLE
feat: add role based start page

### DIFF
--- a/resources/views/start/admin.blade.php
+++ b/resources/views/start/admin.blade.php
@@ -6,24 +6,26 @@
 @stop
 
 @section('content')
-<div class="row">
+<div class="text-center">
+    <h1>Welcome, {{ auth()->user()->present()->name() }}</h1>
     @can('scanning')
-        <div class="col-xs-12 col-sm-6 col-md-3" style="margin-bottom: 15px;">
-            <a href="{{ route('scan') }}" class="btn btn-primary btn-block">Scan QR</a>
-        </div>
+        <a href="{{ route('scan') }}"
+           class="btn btn-primary btn-lg btn-block"
+           style="max-width:300px;margin:15px auto;">
+            <i class="fas fa-camera"></i> Scan QR
+        </a>
     @endcan
     @can('assets.create')
-        <div class="col-xs-12 col-sm-6 col-md-3" style="margin-bottom: 15px;">
-            <a href="{{ route('hardware.create') }}" class="btn btn-primary btn-block">New Asset</a>
-        </div>
+        <a href="{{ route('hardware.create') }}"
+           class="btn btn-primary btn-lg btn-block"
+           style="max-width:300px;margin:15px auto;">
+            <i class="fas fa-plus"></i> New Asset
+        </a>
     @endcan
-    @can('assets.delete')
-        <div class="col-xs-12 col-sm-6 col-md-3" style="margin-bottom: 15px;">
-            <a href="{{ route('hardware.index') }}" class="btn btn-primary btn-block">Management</a>
-        </div>
-    @endcan
-    <div class="col-xs-12 col-sm-6 col-md-3" style="margin-bottom: 15px;">
-        <a href="{{ route('users.index') }}" class="btn btn-primary btn-block">Users</a>
-    </div>
+    <a href="{{ route('home') }}"
+       class="btn btn-primary btn-lg btn-block"
+       style="max-width:300px;margin:15px auto;">
+        <i class="fas fa-cog"></i> Admin Panel
+    </a>
 </div>
 @stop

--- a/resources/views/start/refurbisher.blade.php
+++ b/resources/views/start/refurbisher.blade.php
@@ -6,11 +6,14 @@
 @stop
 
 @section('content')
-<div class="row">
+<div class="text-center">
+    <h1>Welcome, {{ auth()->user()->present()->name() }}</h1>
     @can('scanning')
-        <div class="col-xs-12 col-sm-6 col-md-4" style="margin-bottom: 15px;">
-            <a href="{{ route('scan') }}" class="btn btn-primary btn-block">Scan QR</a>
-        </div>
+        <a href="{{ route('scan') }}"
+           class="btn btn-primary btn-lg btn-block"
+           style="max-width:300px;margin:15px auto;">
+            <i class="fas fa-camera"></i> Scan QR
+        </a>
     @endcan
 </div>
 @stop

--- a/resources/views/start/senior-refurbisher.blade.php
+++ b/resources/views/start/senior-refurbisher.blade.php
@@ -6,16 +6,21 @@
 @stop
 
 @section('content')
-<div class="row">
+<div class="text-center">
+    <h1>Welcome, {{ auth()->user()->present()->name() }}</h1>
     @can('scanning')
-        <div class="col-xs-12 col-sm-6 col-md-4" style="margin-bottom: 15px;">
-            <a href="{{ route('scan') }}" class="btn btn-primary btn-block">Scan QR</a>
-        </div>
+        <a href="{{ route('scan') }}"
+           class="btn btn-primary btn-lg btn-block"
+           style="max-width:300px;margin:15px auto;">
+            <i class="fas fa-camera"></i> Scan QR
+        </a>
     @endcan
     @can('assets.create')
-        <div class="col-xs-12 col-sm-6 col-md-4" style="margin-bottom: 15px;">
-            <a href="{{ route('hardware.create') }}" class="btn btn-primary btn-block">New Asset</a>
-        </div>
+        <a href="{{ route('hardware.create') }}"
+           class="btn btn-primary btn-lg btn-block"
+           style="max-width:300px;margin:15px auto;">
+            <i class="fas fa-plus"></i> New Asset
+        </a>
     @endcan
 </div>
 @stop

--- a/resources/views/start/superuser.blade.php
+++ b/resources/views/start/superuser.blade.php
@@ -6,18 +6,27 @@
 @stop
 
 @section('content')
-<div class="row">
-    <div class="col-xs-12 col-sm-6 col-md-3" style="margin-bottom: 15px;">
-        <a href="{{ route('home') }}" class="btn btn-primary btn-block">Dashboard</a>
-    </div>
-    <div class="col-xs-12 col-sm-6 col-md-3" style="margin-bottom: 15px;">
-        <a href="{{ route('hardware.index') }}" class="btn btn-primary btn-block">Hardware</a>
-    </div>
-    <div class="col-xs-12 col-sm-6 col-md-3" style="margin-bottom: 15px;">
-        <a href="{{ route('users.index') }}" class="btn btn-primary btn-block">Users</a>
-    </div>
-    <div class="col-xs-12 col-sm-6 col-md-3" style="margin-bottom: 15px;">
-        <a href="{{ route('settings.general.index') }}" class="btn btn-primary btn-block">Settings</a>
-    </div>
+<div class="text-center">
+    <h1>Welcome, {{ auth()->user()->present()->name() }}</h1>
+    <a href="{{ route('home') }}"
+       class="btn btn-primary btn-lg btn-block"
+       style="max-width:300px;margin:15px auto;">
+        <i class="fas fa-chart-bar"></i> Dashboard
+    </a>
+    <a href="{{ route('hardware.index') }}"
+       class="btn btn-primary btn-lg btn-block"
+       style="max-width:300px;margin:15px auto;">
+        <i class="fas fa-desktop"></i> Hardware
+    </a>
+    <a href="{{ route('users.index') }}"
+       class="btn btn-primary btn-lg btn-block"
+       style="max-width:300px;margin:15px auto;">
+        <i class="fas fa-users"></i> Users
+    </a>
+    <a href="{{ route('settings.general.index') }}"
+       class="btn btn-primary btn-lg btn-block"
+       style="max-width:300px;margin:15px auto;">
+        <i class="fas fa-cog"></i> Settings
+    </a>
 </div>
 @stop

--- a/resources/views/start/supervisor.blade.php
+++ b/resources/views/start/supervisor.blade.php
@@ -6,21 +6,26 @@
 @stop
 
 @section('content')
-<div class="row">
+<div class="text-center">
+    <h1>Welcome, {{ auth()->user()->present()->name() }}</h1>
     @can('scanning')
-        <div class="col-xs-12 col-sm-6 col-md-4" style="margin-bottom: 15px;">
-            <a href="{{ route('scan') }}" class="btn btn-primary btn-block">Scan QR</a>
-        </div>
+        <a href="{{ route('scan') }}"
+           class="btn btn-primary btn-lg btn-block"
+           style="max-width:300px;margin:15px auto;">
+            <i class="fas fa-camera"></i> Scan QR
+        </a>
     @endcan
     @can('assets.create')
-        <div class="col-xs-12 col-sm-6 col-md-4" style="margin-bottom: 15px;">
-            <a href="{{ route('hardware.create') }}" class="btn btn-primary btn-block">New Asset</a>
-        </div>
+        <a href="{{ route('hardware.create') }}"
+           class="btn btn-primary btn-lg btn-block"
+           style="max-width:300px;margin:15px auto;">
+            <i class="fas fa-plus"></i> New Asset
+        </a>
     @endcan
-    @can('assets.delete')
-        <div class="col-xs-12 col-sm-6 col-md-4" style="margin-bottom: 15px;">
-            <a href="{{ route('hardware.index') }}" class="btn btn-primary btn-block">Management</a>
-        </div>
-    @endcan
+    <a href="{{ route('home') }}"
+       class="btn btn-primary btn-lg btn-block"
+       style="max-width:300px;margin:15px auto;">
+        <i class="fas fa-cog"></i> Admin Panel
+    </a>
 </div>
 @stop

--- a/resources/views/start/user.blade.php
+++ b/resources/views/start/user.blade.php
@@ -6,9 +6,12 @@
 @stop
 
 @section('content')
-<div class="row">
-    <div class="col-xs-12 col-sm-6 col-md-4" style="margin-bottom: 15px;">
-        <a href="{{ route('view-assets') }}" class="btn btn-primary btn-block">My Assets</a>
-    </div>
+<div class="text-center">
+    <h1>Welcome, {{ auth()->user()->present()->name() }}</h1>
+    <a href="{{ route('view-assets') }}"
+       class="btn btn-primary btn-lg btn-block"
+       style="max-width:300px;margin:15px auto;">
+        <i class="fas fa-box"></i> My Assets
+    </a>
 </div>
 @stop


### PR DESCRIPTION
## Summary
- Add role-specific start screens with large action buttons
- Include quick links for scanning, asset creation, and admin panel
- Show personalized welcome on start views

## Testing
- `vendor/bin/phpunit` *(fails: .env.testing file does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68c0d03d5248832dbb7fcff4aba6376f