### PR TITLE
fix migration foreign key

### DIFF
--- a/database/migrations/2025_09_09_000002_create_asset_images_table.php
+++ b/database/migrations/2025_09_09_000002_create_asset_images_table.php
@@ -9,7 +9,10 @@ return new class extends Migration {
     {
         Schema::create('asset_images', function (Blueprint $table) {
             $table->id();
-            $table->unsignedBigInteger('asset_id');
+            // The assets table uses an unsigned integer primary key, so
+            // we need to ensure the foreign key column matches its type
+            // to avoid MySQL foreign key constraint errors.
+            $table->unsignedInteger('asset_id');
             $table->string('file_path');
             $table->string('caption')->nullable();
             $table->timestamps();


### PR DESCRIPTION
## Summary
- fix asset_images table migration to use unsigned integer for asset_id to match assets table

## Testing
- `php -l database/migrations/2025_09_09_000002_create_asset_images_table.php`
- `./vendor/bin/phpunit --filter AssetImages` *(fails: .env.testing file does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68c1c163abe0832d9fe8c45aabb03e10