### PR TITLE
fix migration foreign key

### DIFF
--- a/database/migrations/2025_09_09_000002_create_asset_images_table.php
+++ b/database/migrations/2025_09_09_000002_create_asset_images_table.php
@@ -9,7 +9,7 @@ return new class extends Migration {
     {
         Schema::create('asset_images', function (Blueprint $table) {
             $table->id();
-            $table->unsignedBigInteger('asset_id');
+            $table->unsignedInteger('asset_id');
             $table->string('file_path');
             $table->string('caption')->nullable();
             $table->timestamps();

--- a/database/migrations/2025_09_09_000002_create_asset_status_history_table.php
+++ b/database/migrations/2025_09_09_000002_create_asset_status_history_table.php
@@ -4,19 +4,15 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration
-{
-    /**
-     * Run the migrations.
-     */
+return new class extends Migration {
     public function up(): void
     {
         Schema::create('asset_status_history', function (Blueprint $table) {
-            $table->bigIncrements('id');
-            $table->unsignedBigInteger('asset_id');
-            $table->unsignedBigInteger('old_status_id')->nullable();
-            $table->unsignedBigInteger('new_status_id');
-            $table->unsignedBigInteger('changed_by')->nullable();
+            $table->id();
+            $table->unsignedInteger('asset_id');
+            $table->unsignedInteger('old_status_id')->nullable();
+            $table->unsignedInteger('new_status_id');
+            $table->unsignedInteger('changed_by')->nullable();
             $table->timestamp('changed_at');
 
             $table->foreign('asset_id')->references('id')->on('assets')->onDelete('cascade');
@@ -26,9 +22,6 @@ return new class extends Migration
         });
     }
 
-    /**
-     * Reverse the migrations.
-     */
     public function down(): void
     {
         Schema::dropIfExists('asset_status_history');


### PR DESCRIPTION
## Summary
- remove comments from asset_images migration and keep unsigned integer FK
- fix asset_status_history migration to use unsigned integers for foreign keys

## Testing
- `php -l database/migrations/2025_09_09_000002_create_asset_images_table.php`
- `php -l database/migrations/2025_09_09_000002_create_asset_status_history_table.php`
- `vendor/bin/phpunit --filter AssetImages` *(fails: .env.testing file does not exist)*
- `vendor/bin/phpunit --filter StatusHistory` *(fails: .env.testing file does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68c1c163abe0832d9fe8c45aabb03e10