### PR TITLE
fix migration foreign key types and seeder truncation

### DIFF
--- a/database/migrations/2025_09_09_000000_add_category_id_to_assets_table.php
+++ b/database/migrations/2025_09_09_000000_add_category_id_to_assets_table.php
@@ -8,7 +8,7 @@ return new class extends Migration {
     public function up(): void
     {
         Schema::table('assets', function (Blueprint $table) {
-            $table->integer('category_id')->nullable()->after('model_id');
+            $table->unsignedInteger('category_id')->nullable()->after('model_id');
         });
     }
 

--- a/database/migrations/2025_09_09_000002_create_asset_images_table.php
+++ b/database/migrations/2025_09_09_000002_create_asset_images_table.php
@@ -9,7 +9,7 @@ return new class extends Migration {
     {
         Schema::create('asset_images', function (Blueprint $table) {
             $table->id();
-            $table->unsignedBigInteger('asset_id');
+            $table->unsignedInteger('asset_id');
             $table->string('file_path');
             $table->string('caption')->nullable();
             $table->timestamps();

--- a/database/migrations/2025_09_09_000002_create_asset_status_history_table.php
+++ b/database/migrations/2025_09_09_000002_create_asset_status_history_table.php
@@ -4,19 +4,15 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration
-{
-    /**
-     * Run the migrations.
-     */
+return new class extends Migration {
     public function up(): void
     {
         Schema::create('asset_status_history', function (Blueprint $table) {
-            $table->bigIncrements('id');
-            $table->unsignedBigInteger('asset_id');
-            $table->unsignedBigInteger('old_status_id')->nullable();
-            $table->unsignedBigInteger('new_status_id');
-            $table->unsignedBigInteger('changed_by')->nullable();
+            $table->id();
+            $table->unsignedInteger('asset_id');
+            $table->unsignedInteger('old_status_id')->nullable();
+            $table->unsignedInteger('new_status_id');
+            $table->unsignedInteger('changed_by')->nullable();
             $table->timestamp('changed_at');
 
             $table->foreign('asset_id')->references('id')->on('assets')->onDelete('cascade');
@@ -26,9 +22,6 @@ return new class extends Migration
         });
     }
 
-    /**
-     * Reverse the migrations.
-     */
     public function down(): void
     {
         Schema::dropIfExists('asset_status_history');

--- a/database/migrations/2025_09_09_000004_create_skus_table.php
+++ b/database/migrations/2025_09_09_000004_create_skus_table.php
@@ -9,7 +9,7 @@ return new class extends Migration {
     {
         Schema::create('skus', function (Blueprint $table) {
             $table->id();
-            $table->unsignedBigInteger('model_id');
+            $table->unsignedInteger('model_id');
             $table->string('name');
             $table->timestamps();
             $table->softDeletes();

--- a/database/migrations/2025_09_09_000007_add_sku_id_to_test_runs_table.php
+++ b/database/migrations/2025_09_09_000007_add_sku_id_to_test_runs_table.php
@@ -8,7 +8,7 @@ return new class extends Migration {
     public function up(): void
     {
         Schema::table('test_runs', function (Blueprint $table) {
-            $table->unsignedInteger('sku_id')->nullable()->after('asset_id');
+            $table->unsignedBigInteger('sku_id')->nullable()->after('asset_id');
             $table->foreign('sku_id')->references('id')->on('skus')->nullOnDelete();
         });
     }

--- a/database/seeders/AccessorySeeder.php
+++ b/database/seeders/AccessorySeeder.php
@@ -10,13 +10,16 @@ use Illuminate\Database\Seeder;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Facades\Schema;
 
 class AccessorySeeder extends Seeder
 {
     public function run()
     {
+        Schema::disableForeignKeyConstraints();
         Accessory::truncate();
         DB::table('accessories_checkout')->truncate();
+        Schema::enableForeignKeyConstraints();
 
         if (! Location::count()) {
             $this->call(LocationSeeder::class);

--- a/database/seeders/AssetModelSeeder.php
+++ b/database/seeders/AssetModelSeeder.php
@@ -7,12 +7,15 @@ use App\Models\User;
 use Illuminate\Database\Seeder;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Facades\Schema;
 
 class AssetModelSeeder extends Seeder
 {
     public function run()
     {
+        Schema::disableForeignKeyConstraints();
         AssetModel::truncate();
+        Schema::enableForeignKeyConstraints();
 
         $admin = User::where('permissions->superuser', '1')->first() ?? User::factory()->firstAdmin()->create();
 

--- a/database/seeders/CategorySeeder.php
+++ b/database/seeders/CategorySeeder.php
@@ -5,12 +5,15 @@ namespace Database\Seeders;
 use App\Models\Category;
 use App\Models\User;
 use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\Schema;
 
 class CategorySeeder extends Seeder
 {
     public function run()
     {
+        Schema::disableForeignKeyConstraints();
         Category::truncate();
+        Schema::enableForeignKeyConstraints();
 
         $admin = User::where('permissions->superuser', '1')->first() ?? User::factory()->firstAdmin()->create();
 

--- a/database/seeders/CompanySeeder.php
+++ b/database/seeders/CompanySeeder.php
@@ -6,6 +6,7 @@ use App\Models\Company;
 use Illuminate\Database\Seeder;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Facades\Schema;
 
 class CompanySeeder extends Seeder
 {
@@ -17,7 +18,9 @@ class CompanySeeder extends Seeder
     public function run()
     {
         Log::debug('Seed companies');
+        Schema::disableForeignKeyConstraints();
         Company::truncate();
+        Schema::enableForeignKeyConstraints();
         Company::factory()->count(4)->create();
 
         $src = public_path('/img/demo/companies/');

--- a/database/seeders/ComponentSeeder.php
+++ b/database/seeders/ComponentSeeder.php
@@ -7,13 +7,16 @@ use App\Models\Component;
 use App\Models\Location;
 use Illuminate\Database\Seeder;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
 
 class ComponentSeeder extends Seeder
 {
     public function run()
     {
+        Schema::disableForeignKeyConstraints();
         Component::truncate();
         DB::table('components_assets')->truncate();
+        Schema::enableForeignKeyConstraints();
 
         if (! Company::count()) {
             $this->call(CompanySeeder::class);

--- a/database/seeders/ConsumableSeeder.php
+++ b/database/seeders/ConsumableSeeder.php
@@ -6,13 +6,16 @@ use App\Models\Consumable;
 use App\Models\User;
 use Illuminate\Database\Seeder;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
 
 class ConsumableSeeder extends Seeder
 {
     public function run()
     {
+        Schema::disableForeignKeyConstraints();
         Consumable::truncate();
         DB::table('consumables_users')->truncate();
+        Schema::enableForeignKeyConstraints();
 
         $admin = User::where('permissions->superuser', '1')->first() ?? User::factory()->firstAdmin()->create();
 

--- a/database/seeders/CustomFieldSeeder.php
+++ b/database/seeders/CustomFieldSeeder.php
@@ -22,9 +22,11 @@ class CustomFieldSeeder extends Seeder
                 });
             }
         }
+        Schema::disableForeignKeyConstraints();
         CustomField::truncate();
         CustomFieldset::truncate();
         DB::table('custom_field_custom_fieldset')->truncate();
+        Schema::enableForeignKeyConstraints();
 
         CustomFieldset::factory()->count(1)->mobile()->create();
         CustomFieldset::factory()->count(1)->computer()->create();

--- a/database/seeders/DepartmentSeeder.php
+++ b/database/seeders/DepartmentSeeder.php
@@ -6,12 +6,15 @@ use App\Models\Department;
 use App\Models\Location;
 use App\Models\User;
 use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\Schema;
 
 class DepartmentSeeder extends Seeder
 {
     public function run()
     {
+        Schema::disableForeignKeyConstraints();
         Department::truncate();
+        Schema::enableForeignKeyConstraints();
 
         if (! Location::count()) {
             $this->call(LocationSeeder::class);

--- a/database/seeders/DepreciationSeeder.php
+++ b/database/seeders/DepreciationSeeder.php
@@ -5,12 +5,15 @@ namespace Database\Seeders;
 use App\Models\Depreciation;
 use App\Models\User;
 use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\Schema;
 
 class DepreciationSeeder extends Seeder
 {
     public function run()
     {
+        Schema::disableForeignKeyConstraints();
         Depreciation::truncate();
+        Schema::enableForeignKeyConstraints();
 
         $admin = User::where('permissions->superuser', '1')->first() ?? User::factory()->firstAdmin()->create();
 

--- a/database/seeders/LicenseSeeder.php
+++ b/database/seeders/LicenseSeeder.php
@@ -9,13 +9,16 @@ use App\Models\Supplier;
 use App\Models\User;
 use Illuminate\Database\Seeder;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Schema;
 
 class LicenseSeeder extends Seeder
 {
     public function run()
     {
+        Schema::disableForeignKeyConstraints();
         License::truncate();
         LicenseSeat::truncate();
+        Schema::enableForeignKeyConstraints();
 
         if (! Category::count()) {
             $this->call(CategorySeeder::class);

--- a/database/seeders/LocationSeeder.php
+++ b/database/seeders/LocationSeeder.php
@@ -6,12 +6,15 @@ use App\Models\Location;
 use Illuminate\Database\Seeder;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Facades\Schema;
 
 class LocationSeeder extends Seeder
 {
     public function run()
     {
+        Schema::disableForeignKeyConstraints();
         Location::truncate();
+        Schema::enableForeignKeyConstraints();
         Location::factory()->count(10)->create();
 
         $src = public_path('/img/demo/locations/');

--- a/database/seeders/ManufacturerSeeder.php
+++ b/database/seeders/ManufacturerSeeder.php
@@ -7,12 +7,15 @@ use App\Models\User;
 use Illuminate\Database\Seeder;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Facades\Schema;
 
 class ManufacturerSeeder extends Seeder
 {
     public function run()
     {
+        Schema::disableForeignKeyConstraints();
         Manufacturer::truncate();
+        Schema::enableForeignKeyConstraints();
 
         $admin = User::where('permissions->superuser', '1')->first() ?? User::factory()->firstAdmin()->create();
 

--- a/database/seeders/SettingsSeeder.php
+++ b/database/seeders/SettingsSeeder.php
@@ -6,12 +6,15 @@ use App\Models\Setting;
 use App\Models\User;
 use Illuminate\Database\Seeder;
 use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Facades\Schema;
 
 class SettingsSeeder extends Seeder
 {
     public function run()
     {
+        Schema::disableForeignKeyConstraints();
         Setting::truncate();
+        Schema::enableForeignKeyConstraints();
         $settings = new Setting;
         $settings->per_page = 20;
         $settings->site_name = 'Snipe-IT Demo';

--- a/database/seeders/StatuslabelSeeder.php
+++ b/database/seeders/StatuslabelSeeder.php
@@ -5,12 +5,15 @@ namespace Database\Seeders;
 use App\Models\Statuslabel;
 use App\Models\User;
 use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\Schema;
 
 class StatuslabelSeeder extends Seeder
 {
     public function run()
     {
+        Schema::disableForeignKeyConstraints();
         Statuslabel::truncate();
+        Schema::enableForeignKeyConstraints();
 
         $admin = User::where('permissions->superuser', '1')->first() ?? User::factory()->firstAdmin()->create();
 

--- a/database/seeders/SupplierSeeder.php
+++ b/database/seeders/SupplierSeeder.php
@@ -4,12 +4,15 @@ namespace Database\Seeders;
 
 use App\Models\Supplier;
 use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\Schema;
 
 class SupplierSeeder extends Seeder
 {
     public function run()
     {
+        Schema::disableForeignKeyConstraints();
         Supplier::truncate();
+        Schema::enableForeignKeyConstraints();
         Supplier::factory()->count(5)->create();
     }
 }


### PR DESCRIPTION
## Summary
- align `skus` table `model_id` with `models` IDs using unsigned integer
- use unsigned big integer for `sku_id` in test runs to match `skus` primary key
- ensure `assets` table `category_id` column is unsigned for future foreign keys
- disable foreign key checks while truncating tables in seeders to avoid constraint errors

## Testing
- `php -l database/migrations/2025_09_09_000004_create_skus_table.php`
- `php -l database/migrations/2025_09_09_000007_add_sku_id_to_test_runs_table.php`
- `php -l database/migrations/2025_09_09_000000_add_category_id_to_assets_table.php`
- `php -l database/migrations/2025_09_09_000002_create_asset_images_table.php`
- `php -l database/migrations/2025_09_09_000002_create_asset_status_history_table.php`
- `php -l database/seeders/AccessorySeeder.php`
- `php -l database/seeders/AssetModelSeeder.php`
- `php -l database/seeders/CategorySeeder.php`
- `php -l database/seeders/CompanySeeder.php`
- `php -l database/seeders/ComponentSeeder.php`
- `php -l database/seeders/ConsumableSeeder.php`
- `php -l database/seeders/CustomFieldSeeder.php`
- `php -l database/seeders/DepartmentSeeder.php`
- `php -l database/seeders/DepreciationSeeder.php`
- `php -l database/seeders/LicenseSeeder.php`
- `php -l database/seeders/LocationSeeder.php`
- `php -l database/seeders/ManufacturerSeeder.php`
- `php -l database/seeders/SettingsSeeder.php`
- `php -l database/seeders/StatuslabelSeeder.php`
- `php -l database/seeders/SupplierSeeder.php`
- `composer install --ignore-platform-req=ext-sodium`
- `./vendor/bin/phpunit --filter Seeder` *(no tests executed)*

------
https://chatgpt.com/codex/tasks/task_e_68c1c163abe0832d9fe8c45aabb03e10