### PR TITLE
fix migration foreign key types and seeder truncation

### DIFF
--- a/database/migrations/2025_09_09_000000_add_category_id_to_assets_table.php
+++ b/database/migrations/2025_09_09_000000_add_category_id_to_assets_table.php
@@ -8,7 +8,7 @@ return new class extends Migration {
     public function up(): void
     {
         Schema::table('assets', function (Blueprint $table) {
-            $table->integer('category_id')->nullable()->after('model_id');
+            $table->unsignedInteger('category_id')->nullable()->after('model_id');
         });
     }
 

--- a/database/migrations/2025_09_09_000002_create_asset_images_table.php
+++ b/database/migrations/2025_09_09_000002_create_asset_images_table.php
@@ -9,7 +9,7 @@ return new class extends Migration {
     {
         Schema::create('asset_images', function (Blueprint $table) {
             $table->id();
-            $table->unsignedBigInteger('asset_id');
+            $table->unsignedInteger('asset_id');
             $table->string('file_path');
             $table->string('caption')->nullable();
             $table->timestamps();

--- a/database/migrations/2025_09_09_000002_create_asset_status_history_table.php
+++ b/database/migrations/2025_09_09_000002_create_asset_status_history_table.php
@@ -4,19 +4,15 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration
-{
-    /**
-     * Run the migrations.
-     */
+return new class extends Migration {
     public function up(): void
     {
         Schema::create('asset_status_history', function (Blueprint $table) {
-            $table->bigIncrements('id');
-            $table->unsignedBigInteger('asset_id');
-            $table->unsignedBigInteger('old_status_id')->nullable();
-            $table->unsignedBigInteger('new_status_id');
-            $table->unsignedBigInteger('changed_by')->nullable();
+            $table->id();
+            $table->unsignedInteger('asset_id');
+            $table->unsignedInteger('old_status_id')->nullable();
+            $table->unsignedInteger('new_status_id');
+            $table->unsignedInteger('changed_by')->nullable();
             $table->timestamp('changed_at');
 
             $table->foreign('asset_id')->references('id')->on('assets')->onDelete('cascade');
@@ -26,9 +22,6 @@ return new class extends Migration
         });
     }
 
-    /**
-     * Reverse the migrations.
-     */
     public function down(): void
     {
         Schema::dropIfExists('asset_status_history');

--- a/database/migrations/2025_09_09_000004_create_skus_table.php
+++ b/database/migrations/2025_09_09_000004_create_skus_table.php
@@ -9,7 +9,7 @@ return new class extends Migration {
     {
         Schema::create('skus', function (Blueprint $table) {
             $table->id();
-            $table->unsignedBigInteger('model_id');
+            $table->unsignedInteger('model_id');
             $table->string('name');
             $table->timestamps();
             $table->softDeletes();

--- a/database/migrations/2025_09_09_000007_add_sku_id_to_test_runs_table.php
+++ b/database/migrations/2025_09_09_000007_add_sku_id_to_test_runs_table.php
@@ -8,7 +8,7 @@ return new class extends Migration {
     public function up(): void
     {
         Schema::table('test_runs', function (Blueprint $table) {
-            $table->unsignedInteger('sku_id')->nullable()->after('asset_id');
+            $table->unsignedBigInteger('sku_id')->nullable()->after('asset_id');
             $table->foreign('sku_id')->references('id')->on('skus')->nullOnDelete();
         });
     }

--- a/database/seeders/AccessorySeeder.php
+++ b/database/seeders/AccessorySeeder.php
@@ -15,8 +15,10 @@ class AccessorySeeder extends Seeder
 {
     public function run()
     {
-        Accessory::truncate();
-        DB::table('accessories_checkout')->truncate();
+        DB::table('accessories_checkout')->delete();
+        DB::statement('ALTER TABLE accessories_checkout AUTO_INCREMENT = 1');
+        Accessory::query()->delete();
+        DB::statement('ALTER TABLE accessories AUTO_INCREMENT = 1');
 
         if (! Location::count()) {
             $this->call(LocationSeeder::class);

--- a/database/seeders/AssetModelSeeder.php
+++ b/database/seeders/AssetModelSeeder.php
@@ -5,6 +5,7 @@ namespace Database\Seeders;
 use App\Models\AssetModel;
 use App\Models\User;
 use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
 
@@ -12,7 +13,8 @@ class AssetModelSeeder extends Seeder
 {
     public function run()
     {
-        AssetModel::truncate();
+        AssetModel::query()->delete();
+        DB::statement('ALTER TABLE models AUTO_INCREMENT = 1');
 
         $admin = User::where('permissions->superuser', '1')->first() ?? User::factory()->firstAdmin()->create();
 

--- a/database/seeders/CategorySeeder.php
+++ b/database/seeders/CategorySeeder.php
@@ -5,12 +5,14 @@ namespace Database\Seeders;
 use App\Models\Category;
 use App\Models\User;
 use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
 
 class CategorySeeder extends Seeder
 {
     public function run()
     {
-        Category::truncate();
+        Category::query()->delete();
+        DB::statement('ALTER TABLE categories AUTO_INCREMENT = 1');
 
         $admin = User::where('permissions->superuser', '1')->first() ?? User::factory()->firstAdmin()->create();
 

--- a/database/seeders/CompanySeeder.php
+++ b/database/seeders/CompanySeeder.php
@@ -4,6 +4,7 @@ namespace Database\Seeders;
 
 use App\Models\Company;
 use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
 
@@ -17,7 +18,8 @@ class CompanySeeder extends Seeder
     public function run()
     {
         Log::debug('Seed companies');
-        Company::truncate();
+        Company::query()->delete();
+        DB::statement('ALTER TABLE companies AUTO_INCREMENT = 1');
         Company::factory()->count(4)->create();
 
         $src = public_path('/img/demo/companies/');

--- a/database/seeders/ComponentSeeder.php
+++ b/database/seeders/ComponentSeeder.php
@@ -12,8 +12,10 @@ class ComponentSeeder extends Seeder
 {
     public function run()
     {
-        Component::truncate();
-        DB::table('components_assets')->truncate();
+        DB::table('components_assets')->delete();
+        DB::statement('ALTER TABLE components_assets AUTO_INCREMENT = 1');
+        Component::query()->delete();
+        DB::statement('ALTER TABLE components AUTO_INCREMENT = 1');
 
         if (! Company::count()) {
             $this->call(CompanySeeder::class);

--- a/database/seeders/ConsumableSeeder.php
+++ b/database/seeders/ConsumableSeeder.php
@@ -11,8 +11,10 @@ class ConsumableSeeder extends Seeder
 {
     public function run()
     {
-        Consumable::truncate();
-        DB::table('consumables_users')->truncate();
+        DB::table('consumables_users')->delete();
+        DB::statement('ALTER TABLE consumables_users AUTO_INCREMENT = 1');
+        Consumable::query()->delete();
+        DB::statement('ALTER TABLE consumables AUTO_INCREMENT = 1');
 
         $admin = User::where('permissions->superuser', '1')->first() ?? User::factory()->firstAdmin()->create();
 

--- a/database/seeders/CustomFieldSeeder.php
+++ b/database/seeders/CustomFieldSeeder.php
@@ -22,9 +22,12 @@ class CustomFieldSeeder extends Seeder
                 });
             }
         }
-        CustomField::truncate();
-        CustomFieldset::truncate();
-        DB::table('custom_field_custom_fieldset')->truncate();
+        DB::table('custom_field_custom_fieldset')->delete();
+        DB::statement('ALTER TABLE custom_field_custom_fieldset AUTO_INCREMENT = 1');
+        CustomField::query()->delete();
+        DB::statement('ALTER TABLE custom_fields AUTO_INCREMENT = 1');
+        CustomFieldset::query()->delete();
+        DB::statement('ALTER TABLE custom_fieldsets AUTO_INCREMENT = 1');
 
         CustomFieldset::factory()->count(1)->mobile()->create();
         CustomFieldset::factory()->count(1)->computer()->create();

--- a/database/seeders/DepartmentSeeder.php
+++ b/database/seeders/DepartmentSeeder.php
@@ -6,12 +6,14 @@ use App\Models\Department;
 use App\Models\Location;
 use App\Models\User;
 use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
 
 class DepartmentSeeder extends Seeder
 {
     public function run()
     {
-        Department::truncate();
+        Department::query()->delete();
+        DB::statement('ALTER TABLE departments AUTO_INCREMENT = 1');
 
         if (! Location::count()) {
             $this->call(LocationSeeder::class);

--- a/database/seeders/DepreciationSeeder.php
+++ b/database/seeders/DepreciationSeeder.php
@@ -5,12 +5,14 @@ namespace Database\Seeders;
 use App\Models\Depreciation;
 use App\Models\User;
 use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
 
 class DepreciationSeeder extends Seeder
 {
     public function run()
     {
-        Depreciation::truncate();
+        Depreciation::query()->delete();
+        DB::statement('ALTER TABLE depreciations AUTO_INCREMENT = 1');
 
         $admin = User::where('permissions->superuser', '1')->first() ?? User::factory()->firstAdmin()->create();
 

--- a/database/seeders/LicenseSeeder.php
+++ b/database/seeders/LicenseSeeder.php
@@ -8,14 +8,17 @@ use App\Models\LicenseSeat;
 use App\Models\Supplier;
 use App\Models\User;
 use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 
 class LicenseSeeder extends Seeder
 {
     public function run()
     {
-        License::truncate();
-        LicenseSeat::truncate();
+        LicenseSeat::query()->delete();
+        DB::statement('ALTER TABLE license_seats AUTO_INCREMENT = 1');
+        License::query()->delete();
+        DB::statement('ALTER TABLE licenses AUTO_INCREMENT = 1');
 
         if (! Category::count()) {
             $this->call(CategorySeeder::class);

--- a/database/seeders/LocationSeeder.php
+++ b/database/seeders/LocationSeeder.php
@@ -4,6 +4,7 @@ namespace Database\Seeders;
 
 use App\Models\Location;
 use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
 
@@ -11,7 +12,8 @@ class LocationSeeder extends Seeder
 {
     public function run()
     {
-        Location::truncate();
+        Location::query()->delete();
+        DB::statement('ALTER TABLE locations AUTO_INCREMENT = 1');
         Location::factory()->count(10)->create();
 
         $src = public_path('/img/demo/locations/');

--- a/database/seeders/ManufacturerSeeder.php
+++ b/database/seeders/ManufacturerSeeder.php
@@ -5,6 +5,7 @@ namespace Database\Seeders;
 use App\Models\Manufacturer;
 use App\Models\User;
 use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
 
@@ -12,7 +13,8 @@ class ManufacturerSeeder extends Seeder
 {
     public function run()
     {
-        Manufacturer::truncate();
+        Manufacturer::query()->delete();
+        DB::statement('ALTER TABLE manufacturers AUTO_INCREMENT = 1');
 
         $admin = User::where('permissions->superuser', '1')->first() ?? User::factory()->firstAdmin()->create();
 

--- a/database/seeders/SettingsSeeder.php
+++ b/database/seeders/SettingsSeeder.php
@@ -5,13 +5,15 @@ namespace Database\Seeders;
 use App\Models\Setting;
 use App\Models\User;
 use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Storage;
 
 class SettingsSeeder extends Seeder
 {
     public function run()
     {
-        Setting::truncate();
+        Setting::query()->delete();
+        DB::statement('ALTER TABLE settings AUTO_INCREMENT = 1');
         $settings = new Setting;
         $settings->per_page = 20;
         $settings->site_name = 'Snipe-IT Demo';

--- a/database/seeders/StatuslabelSeeder.php
+++ b/database/seeders/StatuslabelSeeder.php
@@ -5,12 +5,14 @@ namespace Database\Seeders;
 use App\Models\Statuslabel;
 use App\Models\User;
 use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
 
 class StatuslabelSeeder extends Seeder
 {
     public function run()
     {
-        Statuslabel::truncate();
+        Statuslabel::query()->delete();
+        DB::statement('ALTER TABLE statuslabels AUTO_INCREMENT = 1');
 
         $admin = User::where('permissions->superuser', '1')->first() ?? User::factory()->firstAdmin()->create();
 

--- a/database/seeders/SupplierSeeder.php
+++ b/database/seeders/SupplierSeeder.php
@@ -4,12 +4,14 @@ namespace Database\Seeders;
 
 use App\Models\Supplier;
 use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
 
 class SupplierSeeder extends Seeder
 {
     public function run()
     {
-        Supplier::truncate();
+        Supplier::query()->delete();
+        DB::statement('ALTER TABLE suppliers AUTO_INCREMENT = 1');
         Supplier::factory()->count(5)->create();
     }
 }


### PR DESCRIPTION
## Summary
- align `skus` table `model_id` with `models` IDs using unsigned integer
- use unsigned big integer for `sku_id` in test runs to match `skus` primary key
- ensure `assets` table `category_id` column is unsigned for future foreign keys
- replace seeder truncation with delete and auto-increment reset to avoid foreign key constraint violations

## Testing
- `php -l database/migrations/2025_09_09_000004_create_skus_table.php`
- `php -l database/migrations/2025_09_09_000007_add_sku_id_to_test_runs_table.php`
- `php -l database/migrations/2025_09_09_000000_add_category_id_to_assets_table.php`
- `php -l database/migrations/2025_09_09_000002_create_asset_images_table.php`
- `php -l database/migrations/2025_09_09_000002_create_asset_status_history_table.php`
- `for f in database/seeders/AccessorySeeder.php database/seeders/AssetModelSeeder.php database/seeders/CategorySeeder.php database/seeders/CompanySeeder.php database/seeders/ComponentSeeder.php database/seeders/ConsumableSeeder.php database/seeders/CustomFieldSeeder.php database/seeders/DepartmentSeeder.php database/seeders/DepreciationSeeder.php database/seeders/LicenseSeeder.php database/seeders/LocationSeeder.php database/seeders/ManufacturerSeeder.php database/seeders/SettingsSeeder.php database/seeders/StatuslabelSeeder.php database/seeders/SupplierSeeder.php; do php -l $f; done`
- `composer install --ignore-platform-req=ext-sodium`
- `vendor/bin/phpunit --filter Seeder` *(no tests executed)*

------
https://chatgpt.com/codex/tasks/task_e_68c1c163abe0832d9fe8c45aabb03e10