### PR TITLE
Add alternative QR label templates

### DIFF
--- a/config/qr_templates.php
+++ b/config/qr_templates.php
@@ -8,5 +8,17 @@ return [
             'height_mm' => 36,
             'qr_size' => 200,
         ],
+        'dymo-54x25' => [
+            'name' => 'Dymo 54×25mm',
+            'width_mm' => 54,
+            'height_mm' => 25,
+            'qr_size' => 150,
+        ],
+        'square-50' => [
+            'name' => 'Square 50mm',
+            'width_mm' => 50,
+            'height_mm' => 50,
+            'qr_size' => 200,
+        ],
     ],
 ];

--- a/tests/Unit/QrLabelServiceTest.php
+++ b/tests/Unit/QrLabelServiceTest.php
@@ -35,6 +35,19 @@ class QrLabelServiceTest extends TestCase
         Storage::disk('public')->assertExists("labels/qr-v3-dymo-89x36-{$slug}.pdf");
     }
 
+    public function test_generate_supports_alternate_template(): void
+    {
+        Storage::fake('public');
+        $asset = Asset::factory()->create();
+        $service = app(QrLabelService::class);
+
+        $service->generate($asset, 'dymo-54x25');
+
+        $slug = Str::slug($asset->asset_tag);
+        Storage::disk('public')->assertExists("labels/qr-v3-dymo-54x25-{$slug}.png");
+        Storage::disk('public')->assertExists("labels/qr-v3-dymo-54x25-{$slug}.pdf");
+    }
+
     public function test_pdf_falls_back_to_print_date_when_name_missing(): void
     {
         Storage::fake('public');


### PR DESCRIPTION
## Summary
- add 54×25mm and 50×50mm QR label templates
- cover alternate template generation in `QrLabelService` tests

## Testing
- `php artisan test tests/Unit/QrLabelServiceTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68c354ac4ea4832d80dfbbf0a66b748a